### PR TITLE
Fixed issue with resetting background color for Termion backend

### DIFF
--- a/src/backend/termion.rs
+++ b/src/backend/termion.rs
@@ -108,7 +108,7 @@ impl backend::Backend for Concrete {
 
     fn finish(&mut self) {
         print!("{}{}", termion::cursor::Show, termion::cursor::Goto(1, 1));
-        self.clear();
+        print!("{}[49m{}[39m{}", 27 as char, 27 as char, termion::clear::All);
     }
 
     fn init_color_style(&mut self, style: theme::ColorStyle,


### PR DESCRIPTION
Background color was being set back to the theme's background color rather than the terminal's background color when the backend was `finish()`ed.  This resets the background color to the default instead.