### PR TITLE
add shell.nix file for Nix users

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,10 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.stdenv.mkDerivation {
+  name = "cursive-env";
+  buildInputs = with pkgs; [
+    ncurses
+  ];
+
+  RUST_BACKTRACE = 1;
+}


### PR DESCRIPTION
[NixOS](http://nixos.org/) users may need this file to build Cursive if they don't want to install ncurses in their user profile.