### PR TITLE
Correct colors on pancurses+Windows and use strongly typed attributes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ version = "5.85.0"
 [dependencies.pancurses]
 features = ["wide"]
 optional = true
-version = "0.7"
+version = "0.8"
 
 [dependencies.termion]
 optional = true


### PR DESCRIPTION
I've just released a new version of pancurses, which in turn is using an updated version of PDCurses on Windows. Earlier PDCurses defaulted to BGR colors, which caused blue and red to be flipped in Cursive because you use the numbers directly that ncurses does. I now build PDCurses with RGB as I think it's a little bit less surprising that way.

So with the update to pancurses 0.8, Cursive dialogs now look correct on Windows when building against the pancurses backend.

While I was at it I also changed the pancurses backend to use the Attribute and ColorPair types instead of using chtypes directly, as the API is going to become more strongly typed and deprecate the use of just numbers everywhere. Also Window now has the attrget() function so pan::Concrete doesn't need to track the current ColorStyle separately.