### PR TITLE
Use `log` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ optional = true
 version = "0.10"
 
 [dependencies]
+log = "0.3"
 num = "0.1"
 odds = "0.2"
 owning_ref = "0.3"

--- a/src/backend/blt.rs
+++ b/src/backend/blt.rs
@@ -260,8 +260,7 @@ fn blt_keycode_to_char(kc: KeyCode, shift: bool) -> char {
         KeyCode::Num9 => '9',
         KeyCode::Num0 => '0',
         _ => {
-            eprintln!("Found unknown input: {:?}", kc);
-            unreachable!()
+            unreachable!("Found unknown input: {:?}", kc)
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,12 +59,14 @@
 //! Or you can use gdb as usual.
 #![deny(missing_docs)]
 
+#[macro_use]
+extern crate log;
+extern crate num;
+extern crate odds;
+extern crate owning_ref;
 extern crate toml;
 extern crate unicode_segmentation;
 extern crate unicode_width;
-extern crate odds;
-extern crate num;
-extern crate owning_ref;
 
 #[cfg(feature = "termion")]
 #[macro_use]

--- a/src/views/box_view.rs
+++ b/src/views/box_view.rs
@@ -160,7 +160,7 @@ impl<T: View> ViewWrapper for BoxView<T> {
         let result = self.size
             .zip_map(child_size.zip(req), SizeConstraint::result);
 
-        // eprintln!("{:?}", result);
+        debug!("{:?}", result);
 
         if self.squishable {
             // We respect the request if we're less or equal.

--- a/src/views/edit_view.rs
+++ b/src/views/edit_view.rs
@@ -495,7 +495,7 @@ impl View for EditView {
 
     fn layout(&mut self, size: Vec2) {
         self.last_length = size.x;
-        // eprintln!("Promised: {}", size.x);
+        debug!("Promised: {}", size.x);
     }
 
     fn take_focus(&mut self, _: Direction) -> bool {

--- a/src/views/linear_layout.rs
+++ b/src/views/linear_layout.rs
@@ -226,9 +226,9 @@ impl View for LinearLayout {
             .iter_mut()
             .map(|c| c.required_size(req))
             .collect();
-        // eprintln!("Ideal sizes: {:?}", sizes);
+        debug!("Ideal sizes: {:?}", sizes);
         let ideal = self.orientation.stack(sizes.iter());
-        // eprintln!("Ideal result: {:?}", ideal);
+        debug!("Ideal result: {:?}", ideal);
 
 
         // Does it fit?
@@ -241,7 +241,7 @@ impl View for LinearLayout {
         // Ok, so maybe it didn't. Budget cuts, everyone.
         // Let's pretend we have almost no space in this direction.
         let budget_req = req.with_axis(self.orientation, 1);
-        // eprintln!("Budget req: {:?}", budget_req);
+        debug!("Budget req: {:?}", budget_req);
 
         // See how they like it that way
         let min_sizes: Vec<Vec2> = self.children
@@ -249,8 +249,8 @@ impl View for LinearLayout {
             .map(|c| c.required_size(budget_req))
             .collect();
         let desperate = self.orientation.stack(min_sizes.iter());
-        // eprintln!("Min sizes: {:?}", min_sizes);
-        // eprintln!("Desperate: {:?}", desperate);
+        debug!("Min sizes: {:?}", min_sizes);
+        debug!("Desperate: {:?}", desperate);
 
         // This is the lowest we'll ever go. It better fit at least.
         let orientation = self.orientation;
@@ -263,7 +263,7 @@ impl View for LinearLayout {
                 *req.get(self.orientation));
 
             // TODO: print some error message or something
-            // eprintln!("Seriously? {:?} > {:?}???", desperate, req);
+            debug!("Seriously? {:?} > {:?}???", desperate, req);
             // self.cache = Some(SizeCache::build(desperate, req));
             self.cache = None;
             return desperate;
@@ -272,7 +272,7 @@ impl View for LinearLayout {
         // This here is how much we're generously offered
         // (We just checked that req >= desperate, so the subtraction is safe
         let mut available = self.orientation.get(&(req - desperate));
-        // eprintln!("Available: {:?}", available);
+        debug!("Available: {:?}", available);
 
         // Here, we have to make a compromise between the ideal
         // and the desperate solutions.
@@ -282,7 +282,7 @@ impl View for LinearLayout {
             .map(|(a, b)| a.saturating_sub(b))
             .enumerate()
             .collect();
-        // eprintln!("Overweight: {:?}", overweight);
+        debug!("Overweight: {:?}", overweight);
 
         // So... distribute `available` to reduce the overweight...
         // TODO: use child weight in the distribution...
@@ -302,7 +302,7 @@ impl View for LinearLayout {
             allocations[j] = spent;
             available -= spent;
         }
-        // eprintln!("Allocations: {:?}", allocations);
+        debug!("Allocations: {:?}", allocations);
 
         // Final lengths are the minimum ones + generous allocations
         let final_lengths: Vec<Vec2> = min_sizes.iter()
@@ -311,7 +311,7 @@ impl View for LinearLayout {
             .map(|(a, b)| a + b)
             .map(|l| req.with_axis(self.orientation, l))
             .collect();
-        // eprintln!("Final sizes: {:?}", final_lengths);
+        debug!("Final sizes: {:?}", final_lengths);
 
         // Let's ask everyone one last time. Everyone should be happy.
         // (But they may ask more on the other axis.)
@@ -320,7 +320,7 @@ impl View for LinearLayout {
             .enumerate()
             .map(|(i, c)| c.required_size(final_lengths[i]))
             .collect();
-        // eprintln!("Final sizes2: {:?}", final_sizes);
+        debug!("Final sizes2: {:?}", final_sizes);
 
         // Let's stack everything to see what it looks like.
         let compromise = self.orientation.stack(final_sizes.iter());

--- a/src/views/list_view.rs
+++ b/src/views/list_view.rs
@@ -228,7 +228,7 @@ impl View for ListView {
             .max()
             .unwrap_or(0) + 1;
 
-        // eprintln!("Offset: {}", offset);
+        debug!("Offset: {}", offset);
         self.scrollbase.draw(printer, |printer, i| match self.children[i] {
             ListChild::Row(ref label, ref view) => {
                 printer.print((0, 0), label);
@@ -278,7 +278,7 @@ impl View for ListView {
         let available = size.x.saturating_sub(label_width + spacing +
                                               scrollbar_width);
 
-        // eprintln!("Available: {}", available);
+        debug!("Available: {}", available);
 
         for child in self.children.iter_mut().filter_map(ListChild::view) {
             child.layout(Vec2::new(available, 1));

--- a/src/views/text_area.rs
+++ b/src/views/text_area.rs
@@ -80,7 +80,7 @@ impl TextArea {
 
     /// Finds the row containing the grapheme at the given offset
     fn row_at(&self, offset: usize) -> usize {
-        // eprintln!("Offset: {}", offset);
+        debug!("Offset: {}", offset);
         self.rows
             .iter()
             .enumerate()
@@ -201,7 +201,7 @@ impl TextArea {
         if self.is_cache_valid(size) {
             return;
         }
-        // eprintln!("Computing! Oh yeah!");
+        debug!("Computing! Oh yeah!");
 
         let mut available = size.x;
 
@@ -232,7 +232,7 @@ impl TextArea {
         if self.cursor == self.content.len() {
             return;
         }
-        // eprintln!("Rows: {:?}", self.rows);
+        debug!("Rows: {:?}", self.rows);
         let len = self.content[self.cursor..]
             .graphemes(true)
             .next()
@@ -240,13 +240,13 @@ impl TextArea {
             .len();
         let start = self.cursor;
         let end = self.cursor + len;
-        // eprintln!("Start/end: {}/{}", start, end);
-        // eprintln!("Content: `{}`", self.content);
+        debug!("Start/end: {}/{}", start, end);
+        debug!("Content: `{}`", self.content);
         for _ in self.content.drain(start..end) {}
-        // eprintln!("Content: `{}`", self.content);
+        debug!("Content: `{}`", self.content);
 
         let selected_row = self.selected_row();
-        // eprintln!("Selected row: {}", selected_row);
+        debug!("Selected row: {}", selected_row);
         if self.cursor == self.rows[selected_row].end {
             // We're removing an (implicit) newline.
             // This means merging two rows.
@@ -260,10 +260,10 @@ impl TextArea {
         for row in &mut self.rows.iter_mut().skip(1 + selected_row) {
             row.rev_shift(len);
         }
-        // eprintln!("Rows: {:?}", self.rows);
+        debug!("Rows: {:?}", self.rows);
 
         self.fix_damages();
-        // eprintln!("Rows: {:?}", self.rows);
+        debug!("Rows: {:?}", self.rows);
     }
 
     fn insert(&mut self, ch: char) {
@@ -312,7 +312,7 @@ impl TextArea {
 
         // We don't need to go beyond a newline.
         // If we don't find one, end of the text it is.
-        // eprintln!("Cursor: {}", self.cursor);
+        debug!("Cursor: {}", self.cursor);
         let last_byte = self.content[self.cursor..].find('\n').map(|i| {
             1 + i + self.cursor
         });
@@ -321,11 +321,11 @@ impl TextArea {
         });
         let last_byte = last_byte.unwrap_or_else(|| self.content.len());
 
-        // eprintln!("Content: `{}` (len={})",
-        //                 self.content,
-        //                 self.content.len());
-        // eprintln!("start/end: {}/{}", first_byte, last_byte);
-        // eprintln!("start/end rows: {}/{}", first_row, last_row);
+        debug!("Content: `{}` (len={})",
+                        self.content,
+                        self.content.len());
+        debug!("start/end: {}/{}", first_byte, last_byte);
+        debug!("start/end rows: {}/{}", first_row, last_row);
 
         // Do we have access to the entire width?...
         let mut available = size.x;
@@ -337,12 +337,12 @@ impl TextArea {
         }
 
         // First attempt, if scrollbase status didn't change.
-        // eprintln!("Rows: {:?}", self.rows);
+        debug!("Rows: {:?}", self.rows);
         let new_rows =
             make_rows(&self.content[first_byte..last_byte], available);
         // How much did this add?
-        // eprintln!("New rows: {:?}", new_rows);
-        // eprintln!("{}-{}", first_row, last_row);
+        debug!("New rows: {:?}", new_rows);
+        debug!("{}-{}", first_row, last_row);
         let new_row_count = self.rows.len() + new_rows.len() + first_row -
             last_row;
         if !scrollable && new_row_count > size.y {
@@ -373,7 +373,7 @@ impl View for TextArea {
         // Ideally, we'd want x = the longest row + 1
         // (we always keep a space at the end)
         // And y = number of rows
-        // eprintln!("{:?}", self.rows);
+        debug!("{:?}", self.rows);
         let scroll_width = if self.rows.len() > constraint.y { 1 } else { 0 };
         Vec2::new(
             scroll_width + 1 + self.rows.iter().map(|r| r.width).max().unwrap_or(1),
@@ -401,13 +401,13 @@ impl View for TextArea {
                 },
             );
 
-            // eprintln!("Content: `{}`", &self.content);
+            debug!("Content: `{}`", &self.content);
             self.scrollbase.draw(printer, |printer, i| {
-                // eprintln!("Drawing row {}", i);
+                debug!("Drawing row {}", i);
                 let row = &self.rows[i];
-                // eprintln!("row: {:?}", row);
+                debug!("row: {:?}", row);
                 let text = &self.content[row.start..row.end];
-                // eprintln!("row text: `{}`", text);
+                debug!("row text: `{}`", text);
                 printer.with_effect(
                     effect,
                     |printer| { printer.print((0, 0), text); },
@@ -467,7 +467,7 @@ impl View for TextArea {
             _ => return EventResult::Ignored,
         }
 
-        // eprintln!("Rows: {:?}", self.rows);
+        debug!("Rows: {:?}", self.rows);
         let focus = self.selected_row();
         self.scrollbase.scroll_to(focus);
 


### PR DESCRIPTION
This provides a uniform way to handle logging and can be combined with logs from other libraries in end-user apps.

Also removes dependency on `eprintln!()` macro which is stable only recently, in Rust 1.19.