### PR TITLE
Ignore keys properly in SelectView::on_event

### DIFF
--- a/src/views/select_view.rs
+++ b/src/views/select_view.rs
@@ -437,6 +437,8 @@ impl<T: 'static> SelectView<T> {
                     // Apply modulo in case we have a hit
                     // from the chained iterator
                     self.focus.set(i % self.items.len());
+                } else {
+                    return EventResult::Ignored;
                 }
             }
             _ => return EventResult::Ignored,


### PR DESCRIPTION
on_event consumes all keypresses by trying to jump to the item that matches the char. Even if no such item is found, the key event is lost to the rest of the application. By returning EventResult::Ignored when the key press has no effect, the key event that have no effect on the SelectView can still be used by somebody else.