### PR TITLE
Call resize_term on KeySize

### DIFF
--- a/src/backend/curses/pan.rs
+++ b/src/backend/curses/pan.rs
@@ -413,7 +413,10 @@ impl backend::Backend for Concrete {
                     pancurses::Input::KeySUndo => Event::Refresh,
                     pancurses::Input::KeySuspend => Event::Refresh,
                     pancurses::Input::KeyUndo => Event::Refresh,
-                    pancurses::Input::KeyResize => Event::WindowResize,
+                    pancurses::Input::KeyResize => {
+                        pancurses::resize_term(0, 0);
+                        Event::WindowResize
+                    },
                     pancurses::Input::KeyEvent => Event::Refresh,
                     // TODO: mouse support
                     pancurses::Input::KeyMouse => self.parse_mouse_event(),

--- a/src/backend/curses/pan.rs
+++ b/src/backend/curses/pan.rs
@@ -414,7 +414,11 @@ impl backend::Backend for Concrete {
                     pancurses::Input::KeySuspend => Event::Refresh,
                     pancurses::Input::KeyUndo => Event::Refresh,
                     pancurses::Input::KeyResize => {
-                        pancurses::resize_term(0, 0);
+                        // Let pancurses adjust their structures when the window is resized.
+                        // Do it for Windows only, as 'resize_term' is not implemented for Unix
+                        if cfg!(target_os = "windows") {
+                            pancurses::resize_term(0, 0);
+                        }
                         Event::WindowResize
                     },
                     pancurses::Input::KeyEvent => Event::Refresh,


### PR DESCRIPTION
Fix for #182.  We need to call resize_term(0, 0) to adjust pancurses internal structures. See [here](https://github.com/ihalila/pancurses#terminal-resizing)