### PR TITLE
Moving Windows in StackView

### DIFF
--- a/examples/position.rs
+++ b/examples/position.rs
@@ -1,36 +1,112 @@
 extern crate cursive;
 
 use cursive::Cursive;
-use cursive::views::TextView;
-use cursive::views::LayerPosition;
+use cursive::event::Key;
+use cursive::menu::MenuTree;
+use cursive::traits::*;
 use cursive::view::Position;
-
+use cursive::views::Dialog;
+use cursive::views::LayerPosition;
+use cursive::views::TextView;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 /// Moves top layer by the specifyed amount
-fn move_top(mut c: &mut Cursive, x_in: isize, y_in: isize) {
+fn move_top(c: &mut Cursive, x_in: isize, y_in: isize) {
     {
         // Step 1. Get the current position of the layer.
-        let mut s = c.screen_mut();
+        let s = c.screen_mut();
         let l = LayerPosition::FromFront(0);
-        let (x,y) = s.offset().pair();
+        let (x, y) = s.offset().pair();
 
         // Step 2. add the specifed amount
         // (unsigned math in Rust is a mess.)
-        let x = (if x_in < 0 { x - (-x_in) as usize } else { x + x_in as usize });
-        let y = (if y_in < 0 { y - (-y_in) as usize } else { y + y_in as usize });
-        
+        let x = if x_in < 0 {
+            x - (-x_in) as usize
+        } else {
+            x + x_in as usize
+        };
+        let y = if y_in < 0 {
+            y - (-y_in) as usize
+        } else {
+            y + y_in as usize
+        };
+
         // convert the new x and y into a position
-        let p = Position::absolute((x,y));
+        let p = Position::absolute((x, y));
 
         // Step 3. Apply the new position
         s.reposition_layer(l, p);
     }
     // Step 4. clean the screen cos we made it dirty.
-    c.clear();
+    //c.clear();
 }
 
 fn main() {
     let mut siv = Cursive::new();
+
+    // We'll use a counter to name new files.
+    let counter = AtomicUsize::new(1);
+
+    // The menubar is a list of (label, menu tree) pairs.
+    siv.menubar()
+        // We add a new "File" tree
+        .add_subtree("File",
+             MenuTree::new()
+                 // Trees are made of leaves, with are directly actionable...
+                 .leaf("New", move |s| {
+                     // Here we use the counter to add an entry
+                     // in the list of "Recent" items.
+                     let i = counter.fetch_add(1, Ordering::Relaxed);
+                     let filename = format!("New {}", i);
+                     s.menubar().find_subtree("File").unwrap()
+                                .find_subtree("Recent").unwrap()
+                                .insert_leaf(0, filename, |_| ());
+
+                     s.add_layer(Dialog::info("New file!"));
+                 })
+                 // ... and of sub-trees, which open up when selected.
+                 .subtree("Recent",
+                          // The `.with()` method can help when running loops
+                          // within builder patterns.
+                          MenuTree::new().with(|tree| {
+                              for i in 1..100 {
+                                  // We don't actually do anything here,
+                                  // but you could!
+                                  tree.add_leaf(format!("Item {}", i), |_| ())
+                              }
+                          }))
+                 // Delimiter are simple lines between items,
+                 // and cannot be selected.
+                 .delimiter()
+                 .with(|tree| {
+                     for i in 1..10 {
+                         tree.add_leaf(format!("Option {}", i), |_| ());
+                     }
+                 }))
+        .add_subtree("Help",
+             MenuTree::new()
+                 .subtree("Help",
+                          MenuTree::new()
+                              .leaf("General", |s| {
+                                  s.add_layer(Dialog::info("Help message!"))
+                              })
+                              .leaf("Online", |s| {
+                                  let text = "Google it yourself!\n\
+                                              Kids, these days...";
+                                  s.add_layer(Dialog::info(text))
+                              }))
+                 .leaf("About",
+                       |s| s.add_layer(Dialog::info("Cursive v0.0.0"))))
+        .add_delimiter()
+        .add_leaf("Quit", |s| s.quit());
+
+    // When `autohide` is on (default), the menu only appears when active.
+    // Turning it off will leave the menu always visible.
+    // Try uncommenting this line!
+
+    // siv.set_autohide_menu(false);
+
+    siv.add_global_callback(Key::Esc, |s| s.select_menubar());
 
     // We can quit by pressing `q`
     siv.add_global_callback('q', Cursive::quit);
@@ -41,7 +117,8 @@ fn main() {
 
     // Add a simple view
     siv.add_layer(TextView::new(
-        "Press w,a,s,d to move the window.\n\
+        "Hit <Esc> to show the menu!\n\n\
+         Press w,a,s,d to move the window.\n\
          Press q to quit the application.",
     ));
 

--- a/examples/position.rs
+++ b/examples/position.rs
@@ -1,16 +1,11 @@
 extern crate cursive;
 
 use cursive::Cursive;
-use cursive::event::Key;
-use cursive::menu::MenuTree;
-use cursive::traits::*;
 use cursive::view::Position;
-use cursive::views::Dialog;
 use cursive::views::LayerPosition;
 use cursive::views::TextView;
-use std::sync::atomic::{AtomicUsize, Ordering};
 
-/// Moves top layer by the specifyed amount
+/// Moves top layer by the specified amount
 fn move_top(c: &mut Cursive, x_in: isize, y_in: isize) {
     // Step 1. Get the current position of the layer.
     let s = c.screen_mut();
@@ -42,85 +37,17 @@ fn main() {
     let mut siv = Cursive::new();
     siv.set_fps(60);
 
-    // We'll use a counter to name new files.
-    let counter = AtomicUsize::new(1);
-
-    // This is a direct copy of the menubar example.
-
-    // The menubar is a list of (label, menu tree) pairs.
-    siv.menubar()
-        // We add a new "File" tree
-        .add_subtree("File",
-             MenuTree::new()
-                 // Trees are made of leaves, with are directly actionable...
-                 .leaf("New", move |s| {
-                     // Here we use the counter to add an entry
-                     // in the list of "Recent" items.
-                     let i = counter.fetch_add(1, Ordering::Relaxed);
-                     let filename = format!("New {}", i);
-                     s.menubar().find_subtree("File").unwrap()
-                                .find_subtree("Recent").unwrap()
-                                .insert_leaf(0, filename, |_| ());
-
-                     s.add_layer(Dialog::info("New file!"));
-                 })
-                 // ... and of sub-trees, which open up when selected.
-                 .subtree("Recent",
-                          // The `.with()` method can help when running loops
-                          // within builder patterns.
-                          MenuTree::new().with(|tree| {
-                              for i in 1..100 {
-                                  // We don't actually do anything here,
-                                  // but you could!
-                                  tree.add_leaf(format!("Item {}", i), |_| ())
-                              }
-                          }))
-                 // Delimiter are simple lines between items,
-                 // and cannot be selected.
-                 .delimiter()
-                 .with(|tree| {
-                     for i in 1..10 {
-                         tree.add_leaf(format!("Option {}", i), |_| ());
-                     }
-                 }))
-        .add_subtree("Help",
-             MenuTree::new()
-                 .subtree("Help",
-                          MenuTree::new()
-                              .leaf("General", |s| {
-                                  s.add_layer(Dialog::info("Help message!"))
-                              })
-                              .leaf("Online", |s| {
-                                  let text = "Google it yourself!\n\
-                                              Kids, these days...";
-                                  s.add_layer(Dialog::info(text))
-                              }))
-                 .leaf("About",
-                       |s| s.add_layer(Dialog::info("Cursive v0.0.0"))))
-        .add_delimiter()
-        .add_leaf("Quit", |s| s.quit());
-
-    // When `autohide` is on (default), the menu only appears when active.
-    // Turning it off will leave the menu always visible.
-    // Try uncommenting this line!
-
-    // siv.set_autohide_menu(false);
-
-    siv.add_global_callback(Key::Esc, |s| s.select_menubar());
-
-    // END OF MENUBAR
-
     // We can quit by pressing `q`
     siv.add_global_callback('q', Cursive::quit);
+    // Next Gen FPS Controls.
     siv.add_global_callback('w', |s| move_top(s, 0, -1));
     siv.add_global_callback('a', |s| move_top(s, -1, 0));
     siv.add_global_callback('s', |s| move_top(s, 0, 1));
     siv.add_global_callback('d', |s| move_top(s, 1, 0));
 
-    // Add a simple view
+    // Add window to fly around.
     siv.add_layer(TextView::new(
-        "Hit <Esc> to show the menu!\n\n\
-         Press w,a,s,d to move the window.\n\
+        "Press w,a,s,d to move the window.\n\
          Press q to quit the application.",
     ));
 

--- a/examples/position.rs
+++ b/examples/position.rs
@@ -5,47 +5,28 @@ use cursive::views::TextView;
 use cursive::views::LayerPosition;
 use cursive::view::Position;
 
-fn move_a(mut c: &mut Cursive) {
-    let mut s = c.screen_mut();
-    let l = LayerPosition::FromFront(0);
-    let (x,y) = s.offset().pair();
-    let x = x - 1;
 
-    let p = Position::absolute((x,y));
-    s.reposition_layer(l, p);
-}
-
-fn move_w(mut c: &mut Cursive) {
-    let mut s = c.screen_mut();
-    let l = LayerPosition::FromFront(0);
-    let (x,y) = s.offset().pair();
-    let y = y - 1;
-
-    let p = Position::absolute((x,y));
-    s.reposition_layer(l, p);
-}
-
-fn move_s(mut c: &mut Cursive) {
+/// Moves top layer by the specifyed amount
+fn move_top(mut c: &mut Cursive, x_in: isize, y_in: isize) {
     {
+        // Step 1. Get the current position of the layer.
         let mut s = c.screen_mut();
         let l = LayerPosition::FromFront(0);
         let (x,y) = s.offset().pair();
-        let y = y + 1;
 
+        // Step 2. add the specifed amount
+        // (unsigned math in Rust is a mess.)
+        let x = (if x_in < 0 { x - (-x_in) as usize } else { x + x_in as usize });
+        let y = (if y_in < 0 { y - (-y_in) as usize } else { y + y_in as usize });
+        
+        // convert the new x and y into a position
         let p = Position::absolute((x,y));
+
+        // Step 3. Apply the new position
         s.reposition_layer(l, p);
     }
+    // Step 4. clean the screen cos we made it dirty.
     c.clear();
-}
-
-fn move_d(mut c: &mut Cursive) {
-    let mut s = c.screen_mut();
-    let l = LayerPosition::FromFront(0);
-    let (x,y) = s.offset().pair();
-    let x = x + 1;
-
-    let p = Position::absolute((x,y));
-    s.reposition_layer(l, p);
 }
 
 fn main() {
@@ -53,10 +34,10 @@ fn main() {
 
     // We can quit by pressing `q`
     siv.add_global_callback('q', Cursive::quit);
-    siv.add_global_callback('w', |s| move_w(s));
-    siv.add_global_callback('a', |s| move_a(s));
-    siv.add_global_callback('s', |s| move_s(s));
-    siv.add_global_callback('d', |s| move_d(s));
+    siv.add_global_callback('w', |s| move_top(s, 0, -1));
+    siv.add_global_callback('a', |s| move_top(s, -1, 0));
+    siv.add_global_callback('s', |s| move_top(s, 0, 1));
+    siv.add_global_callback('d', |s| move_top(s, 1, 0));
 
     // Add a simple view
     siv.add_layer(TextView::new(

--- a/examples/position.rs
+++ b/examples/position.rs
@@ -12,33 +12,30 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 /// Moves top layer by the specifyed amount
 fn move_top(c: &mut Cursive, x_in: isize, y_in: isize) {
-    {
-        // Step 1. Get the current position of the layer.
-        let s = c.screen_mut();
-        let l = LayerPosition::FromFront(0);
-        let (x, y) = s.offset().pair();
+    // Step 1. Get the current position of the layer.
+    let s = c.screen_mut();
+    let l = LayerPosition::FromFront(0);
 
-        // Step 2. add the specifed amount
-        // (unsigned math in Rust is a mess.)
-        let x = if x_in < 0 {
-            x - (-x_in) as usize
-        } else {
-            x + x_in as usize
-        };
-        let y = if y_in < 0 {
-            y - (-y_in) as usize
-        } else {
-            y + y_in as usize
-        };
+    let (x, y) = s.offset().pair();
 
-        // convert the new x and y into a position
-        let p = Position::absolute((x, y));
+    // Step 2. add the specifed amount
+    // (unsigned math in Rust is a mess.)
+    let x = if x_in < 0 {
+        x - (-x_in) as usize
+    } else {
+        x + x_in as usize
+    };
+    let y = if y_in < 0 {
+        y - (-y_in) as usize
+    } else {
+        y + y_in as usize
+    };
 
-        // Step 3. Apply the new position
-        s.reposition_layer(l, p);
-    }
-    // Step 4. clean the screen cos we made it dirty.
-    //c.clear();
+    // convert the new x and y into a position
+    let p = Position::absolute((x, y));
+
+    // Step 3. Apply the new position
+    s.reposition_layer(l, p);
 }
 
 fn main() {
@@ -47,6 +44,8 @@ fn main() {
 
     // We'll use a counter to name new files.
     let counter = AtomicUsize::new(1);
+
+    // This is a direct copy of the menubar example.
 
     // The menubar is a list of (label, menu tree) pairs.
     siv.menubar()
@@ -108,6 +107,8 @@ fn main() {
     // siv.set_autohide_menu(false);
 
     siv.add_global_callback(Key::Esc, |s| s.select_menubar());
+
+    // END OF MENUBAR
 
     // We can quit by pressing `q`
     siv.add_global_callback('q', Cursive::quit);

--- a/examples/position.rs
+++ b/examples/position.rs
@@ -43,6 +43,7 @@ fn move_top(c: &mut Cursive, x_in: isize, y_in: isize) {
 
 fn main() {
     let mut siv = Cursive::new();
+    siv.set_fps(60);
 
     // We'll use a counter to name new files.
     let counter = AtomicUsize::new(1);

--- a/examples/position.rs
+++ b/examples/position.rs
@@ -1,0 +1,69 @@
+extern crate cursive;
+
+use cursive::Cursive;
+use cursive::views::TextView;
+use cursive::views::LayerPosition;
+use cursive::view::Position;
+
+fn move_a(mut c: &mut Cursive) {
+    let mut s = c.screen_mut();
+    let l = LayerPosition::FromFront(0);
+    let (x,y) = s.offset().pair();
+    let x = x - 1;
+
+    let p = Position::absolute((x,y));
+    s.reposition_layer(l, p);
+}
+
+fn move_w(mut c: &mut Cursive) {
+    let mut s = c.screen_mut();
+    let l = LayerPosition::FromFront(0);
+    let (x,y) = s.offset().pair();
+    let y = y - 1;
+
+    let p = Position::absolute((x,y));
+    s.reposition_layer(l, p);
+}
+
+fn move_s(mut c: &mut Cursive) {
+    {
+        let mut s = c.screen_mut();
+        let l = LayerPosition::FromFront(0);
+        let (x,y) = s.offset().pair();
+        let y = y + 1;
+
+        let p = Position::absolute((x,y));
+        s.reposition_layer(l, p);
+    }
+    c.clear();
+}
+
+fn move_d(mut c: &mut Cursive) {
+    let mut s = c.screen_mut();
+    let l = LayerPosition::FromFront(0);
+    let (x,y) = s.offset().pair();
+    let x = x + 1;
+
+    let p = Position::absolute((x,y));
+    s.reposition_layer(l, p);
+}
+
+fn main() {
+    let mut siv = Cursive::new();
+
+    // We can quit by pressing `q`
+    siv.add_global_callback('q', Cursive::quit);
+    siv.add_global_callback('w', |s| move_w(s));
+    siv.add_global_callback('a', |s| move_a(s));
+    siv.add_global_callback('s', |s| move_s(s));
+    siv.add_global_callback('d', |s| move_d(s));
+
+    // Add a simple view
+    siv.add_layer(TextView::new(
+        "Press w,a,s,d to move the window.\n\
+         Press q to quit the application.",
+    ));
+
+    // Run the event loop
+    siv.run();
+}

--- a/src/cursive.rs
+++ b/src/cursive.rs
@@ -419,7 +419,7 @@ impl Cursive {
         self.screen_mut().pop_layer()
     }
 
-    /// Convenient stub forwaring layer repositioning.
+    /// Convenient stub forwarding layer repositioning.
     pub fn reposition_layer(
         &mut self, layer: LayerPosition, position: Position
     ) {
@@ -467,12 +467,12 @@ impl Cursive {
 
         let selected = self.menubar.receive_events();
 
-        // Print the screen before the menubar
-        // else the screen might draw over it and hide it
+        // Print the stackview background before the menubar
         let offset = if self.menubar.autohide { 0 } else { 1 };
-        let printer = printer.offset((0, offset), !selected);
         let id = self.active_screen;
-        self.screens[id].draw(&printer);
+        let sv_printer = printer.offset((0, offset), !selected);
+
+        self.screens[id].draw_bg(&sv_printer);
 
         // Draw the currently active screen
         // If the menubar is active, nothing else can be.
@@ -485,6 +485,10 @@ impl Cursive {
             );
             self.menubar.draw(&printer);
         }
+
+        // finally draw stackview layers
+        // using variables from above
+        self.screens[id].draw_fg(&sv_printer);
     }
 
     /// Returns `true` until [`quit(&mut self)`] is called.

--- a/src/cursive.rs
+++ b/src/cursive.rs
@@ -416,9 +416,7 @@ impl Cursive {
 
     /// Convenient method to remove a layer from the current screen.
     pub fn pop_layer(&mut self) -> Option<Box<AnyView>> {
-        let result = self.screen_mut().pop_layer();
-        self.clear();
-        result
+        self.screen_mut().pop_layer()
     }
 
     // Handles a key event when it was ignored by the current view
@@ -460,6 +458,15 @@ impl Cursive {
         let printer =
             Printer::new(self.screen_size(), &self.theme, &self.backend);
 
+        let selected = self.menubar.receive_events();
+
+        // Print the screen before the menubar
+        // else the screen might draw over it and hide it
+        let offset = if self.menubar.autohide { 0 } else { 1 };
+        let printer = printer.offset((0, offset), !selected);
+        let id = self.active_screen;
+        self.screens[id].draw(&printer);
+
         // Draw the currently active screen
         // If the menubar is active, nothing else can be.
         // Draw the menubar?
@@ -471,13 +478,6 @@ impl Cursive {
             );
             self.menubar.draw(&printer);
         }
-
-        let selected = self.menubar.receive_events();
-
-        let offset = if self.menubar.autohide { 0 } else { 1 };
-        let printer = printer.offset((0, offset), !selected);
-        let id = self.active_screen;
-        self.screens[id].draw(&printer);
     }
 
     /// Returns `true` until [`quit(&mut self)`] is called.

--- a/src/cursive.rs
+++ b/src/cursive.rs
@@ -9,8 +9,8 @@ use std::path::Path;
 use std::sync::mpsc;
 use theme;
 use vec::Vec2;
-use view::{self, AnyView, Finder, View};
-use views;
+use view::{self, AnyView, Finder, Position, View};
+use views::{self, LayerPosition};
 
 /// Identifies a screen in the cursive root.
 pub type ScreenId = usize;
@@ -417,6 +417,13 @@ impl Cursive {
     /// Convenient method to remove a layer from the current screen.
     pub fn pop_layer(&mut self) -> Option<Box<AnyView>> {
         self.screen_mut().pop_layer()
+    }
+
+    /// Convenient stub forwaring layer repositioning.
+    pub fn reposition_layer(
+        &mut self, layer: LayerPosition, position: Position
+    ) {
+        self.screen_mut().reposition_layer(layer, position);
     }
 
     // Handles a key event when it was ignored by the current view

--- a/src/views/stack_view.rs
+++ b/src/views/stack_view.rs
@@ -281,6 +281,19 @@ impl StackView {
         self.move_layer(layer, LayerPosition::FromBack(0));
     }
 
+    /// Gets screen coords of thingy.
+    pub fn get_layer_position(&mut self, layer: LayerPosition,) -> Option<&Position> {
+        let i = self.get_index(layer);
+        let child =  match self.layers.get_mut(i) {
+            Some(i) => i,
+            None => return None,
+        };
+        match child.placement {
+            Placement::Floating(ref p) => Some(p),
+            Placement::Fullscreen => None,
+        }
+    }
+    
     /// Moves a layer to a new position on the screen.
     ///
     /// Has no effect on fullscreen layers

--- a/src/views/stack_view.rs
+++ b/src/views/stack_view.rs
@@ -280,6 +280,22 @@ impl StackView {
     pub fn move_to_back(&mut self, layer: LayerPosition) {
         self.move_layer(layer, LayerPosition::FromBack(0));
     }
+
+    /// Moves a layer to a new position on the screen.
+    ///
+    /// Has no effect on fullscreen layers
+    /// Has no effect if layer is not found
+    pub fn reposition_layer(&mut self, layer: LayerPosition, position: Position) {
+        let i = self.get_index(layer);
+        let child =  match self.layers.get_mut(i) {
+            Some(i) => i,
+            None => return,
+        };
+        match child.placement {
+            Placement::Floating(_) => child.placement = Placement::Floating(position),
+            Placement::Fullscreen => (),
+        }
+    }
 }
 
 struct StackPositionIterator<R: Deref<Target = Child>, I: Iterator<Item = R>> {

--- a/src/views/stack_view.rs
+++ b/src/views/stack_view.rs
@@ -281,19 +281,7 @@ impl StackView {
         self.move_layer(layer, LayerPosition::FromBack(0));
     }
 
-    /// Gets screen coords of thingy.
-    pub fn get_layer_position(&mut self, layer: LayerPosition,) -> Option<&Position> {
-        let i = self.get_index(layer);
-        let child =  match self.layers.get_mut(i) {
-            Some(i) => i,
-            None => return None,
-        };
-        match child.placement {
-            Placement::Floating(ref p) => Some(p),
-            Placement::Fullscreen => None,
-        }
-    }
-    
+
     /// Moves a layer to a new position on the screen.
     ///
     /// Has no effect on fullscreen layers


### PR DESCRIPTION
This PR adds the ability to move a child of a stackView in the screen space using a new function `reposition_layer()`. With this functionality new handling of exposed background space was needed, so this responsibility was moved from `cursive::Cursive` into the stackView. Handling of background drawing was changed from a `clear()` call, which is unavailable to a series of printing commands, gated by a dirty flag. This new drawing method sees a performance improvement in applications previously making a lot of clear calls.

 Currently all commands that previously invoked `clear()` in `cursive::Cursive` now set the dirty flag:

- `pop_layer()`
- `reposition_layer()`
- handling `WindowChange` Events

Finally an example `./examples/position.rs` was crafted that demonstrates a movable window, and includes the menubar example to prove the new rendering does not break menu bars.

- **Rustfmt:** Formatted
- **Tests:** Passed Locally

_This is my first PR. Be gentle_

\- Segfault.