### PR TITLE
Allow FnOnce callbacks in cb_sink

### DIFF
--- a/src/cursive.rs
+++ b/src/cursive.rs
@@ -526,7 +526,7 @@ impl Cursive {
     ///
     /// [`run(&mut self)`]: #method.run
     pub fn step(&mut self) {
-        if let Ok(cb) = self.cb_source.try_recv() {
+        while let Ok(cb) = self.cb_source.try_recv() {
             cb(self);
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,7 @@ mod utf8;
 #[doc(hidden)]
 pub mod backend;
 
-pub use cursive::{Cursive, ScreenId};
+pub use cursive::{CbFunc, Cursive, ScreenId};
 pub use printer::Printer;
 pub use with::With;
 pub use xy::XY;


### PR DESCRIPTION
This is unfortunately changing the API but it makes dealing with callbacks much easier.
This PR also modifies that multiple callbacks can be run at each step. (The documentation suggested it worked like this before: "Callbacks will be executed in the order of arrival on the next event cycle.")
