### PR TITLE
make SelectView less greedy

### DIFF
--- a/src/views/select_view.rs
+++ b/src/views/select_view.rs
@@ -677,7 +677,9 @@ impl<T: 'static> View for SelectView<T> {
             // Add 2 spaces for the scrollbar if we need
             let w = if scrolling { w + 2 } else { w };
 
-            Vec2::new(w, h)
+            // Don't request more than we're offered - we can scroll,
+            // after all
+            Vec2::new(w, min(h, req.y))
         }
     }
 


### PR DESCRIPTION
Huh, turns out the bug I wanted to fix with this is more nuanced than I thought at first. Anyway, here's one solution that worked for me.

Now, to demonstrate what happened, take a look at the results of this code:

```rust
extern crate cursive;

use cursive::Cursive;
use cursive::traits::Boxable;
use cursive::views::{LinearLayout, SelectView, Dialog};

fn main() {
    let mut siv = Cursive::new();

    // We can quit by pressing `q`
    siv.add_global_callback('q', Cursive::quit);

    // Add a simple view
    siv.add_layer(Dialog::around(LinearLayout::horizontal()
                                 .child(SelectView::new()
                                        .item_str("I want it all")
                                        .item_str("I want it all")
                                        .item_str("I want it all")
                                        .item_str("And I want it")
                                        .item_str("Now!")
                                        .full_width()
                                        )
                                 .child(SelectView::new()
                                        .item_str("I want it all")
                                        .item_str("I want it all")
                                        .item_str("I want it all")
                                        .item_str("And I want it")
                                        .item_str("Now!")
                                        .full_width()
                                        )
                                 .full_width())
                  .title("Layout Panic!")
                  .max_height(4));

    // Run the event loop
    siv.run();
}
```

I expected it to look like this:
<img width="512" alt="screen shot 2018-03-01 at 21 41 23" src="https://user-images.githubusercontent.com/871405/36868675-60b4df6a-1d99-11e8-9289-a1043ecf19a5.png">


But before this patch, what actually happened was this:
<img width="514" alt="screen shot 2018-03-01 at 21 40 43" src="https://user-images.githubusercontent.com/871405/36868681-65ba5ae4-1d99-11e8-845a-aad70981257d.png">


As you can see, both `SelectView`s are **horizontally** collapsed, despite the fact that they got wrapped in `full_width` `BoxView`s!

I tracked it down to the fact that `SelectView` always requests as much space as it has items:
```rust
fn required_size(&mut self, req: Vec2) -> Vec2 {
    // Items here are not compressible.
    // So no matter what the horizontal requirements are,
    // we'll still return our longest item.
    let w = self.items
        .iter()
        .map(|item| item.label.width())
        .max()
        .unwrap_or(1);
    if self.popup {
        Vec2::new(w + 2, 1)
    } else {
        let h = self.items.len();

        let scrolling = req.y < h;

        // Add 2 spaces for the scrollbar if we need
        let w = if scrolling { w + 2 } else { w };

        // Don't request more than we're offered - we can scroll,
        // after all
        Vec2::new(w, h) // min(h, req.y))
    }
}
```

This frustrates `LinearLayout`, so it gives up after computing its `desparate` layout:
```
// This is the lowest we'll ever go. It better fit at least.
let orientation = self.orientation;
if !desperate.fits_in(req) {
    // Just give up...
    // TODO: hard-cut
    cap(
        self.children
            .iter_mut()
            .map(|c| c.size.get_mut(orientation)),
        *req.get(self.orientation),
    );

    // TODO: print some error message or something
    debug!("Seriously? {:?} > {:?}???", desperate, req);
    // self.cache = Some(SizeCache::build(desperate, req));
    self.cache = None;
    return desperate;
}
```

I didn't look into it further, since my change fixed the problem (and I didn't realize until 15 minutes ago that it only appeared when using `full_width`), but `BoxView` seems to also bear a bit of the blame - apparently it does something to `SelectView`'s `required_size` output that causes this behavior?

So, there should probably be two more PRs:

1. Change `LinearLayout` to not freak out about child views not fitting in the dimension it doesn't control (since it can't do anything about that anyway)
2. Fix whatever is going on in `BoxView`

If you'd like me to, I can take a shot at 1, but I can't even tell what's going wrong with 2 at a glance, so advice would be appreciated :)