### PR TITLE
Option to include identifier in stackview and move by id

### DIFF
--- a/examples/mutation.rs
+++ b/examples/mutation.rs
@@ -41,6 +41,7 @@ fn show_popup(siv: &mut Cursive) {
                 });
             })
             .dismiss_button("Ok"),
+        None,
     );
 }
 

--- a/src/cursive.rs
+++ b/src/cursive.rs
@@ -455,7 +455,7 @@ impl Cursive {
     /// # }
     /// ```
     pub fn add_layer<T: 'static + View>(&mut self, view: T) {
-        self.screen_mut().add_layer(view);
+        self.screen_mut().add_layer(view, None);
     }
 
     /// Adds a new full-screen layer to the current screen.
@@ -465,7 +465,7 @@ impl Cursive {
     where
         T: 'static + View,
     {
-        self.screen_mut().add_fullscreen_layer(view);
+        self.screen_mut().add_fullscreen_layer(view, None);
     }
 
     /// Convenient method to remove a layer from the current screen.

--- a/src/views/menu_popup.rs
+++ b/src/views/menu_popup.rs
@@ -162,7 +162,7 @@ impl MenuPopup {
                         }
                     },
                 )).on_event(Key::Left, |s| s.pop_layer()),
-            );
+            None);
         })
     }
 

--- a/src/views/menubar.rs
+++ b/src/views/menubar.rs
@@ -255,6 +255,7 @@ fn show_child(s: &mut Cursive, offset: Vec2, menu: Rc<MenuTree>) {
                     cb(s);
                 }
             }),
+        None
     );
 }
 

--- a/src/views/select_view.rs
+++ b/src/views/select_view.rs
@@ -541,6 +541,7 @@ impl<T: 'static> SelectView<T> {
             s.screen_mut().add_layer_at(
                 Position::parent(offset),
                 MenuPopup::new(tree).focus(focus),
+                None,
             );
         })
     }

--- a/src/views/stack_view.rs
+++ b/src/views/stack_view.rs
@@ -134,6 +134,7 @@ impl<T: View> View for ChildWrapper<T> {
 struct Child {
     view: ChildWrapper<Box<AnyView>>,
     size: Vec2,
+    id: Option<String>,
     placement: Placement,
 
     // We cannot call `take_focus` until we've called `layout()`
@@ -155,16 +156,34 @@ impl StackView {
         }
     }
 
+    /// Pushes the view with the given ID to the front of the stack
+    pub fn child_pos_with_view_id(&mut self, id:&str) -> Option<usize> {
+        self.layers.iter()
+            .position(|l| {
+                if let Some(c) = l.id.clone() {
+                    if c.as_str() == id {
+                        return true;
+                    }
+                }
+                false
+            })
+    }
+
     /// Adds a new full-screen layer on top of the stack.
     ///
     /// Fullscreen layers have no shadow.
-    pub fn add_fullscreen_layer<T>(&mut self, view: T)
+    pub fn add_fullscreen_layer<T>(&mut self, view: T, id: Option<&str>)
     where
         T: 'static + View,
     {
         let boxed: Box<AnyView> = Box::new(view);
+        let id = match id {
+            Some(s) => Some(s.to_string()),
+            None => None,
+        };
         self.layers.push(Child {
             view: ChildWrapper::Plain(Layer::new(boxed)),
+            id: id,
             size: Vec2::zero(),
             placement: Placement::Fullscreen,
             virgin: true,
@@ -172,39 +191,43 @@ impl StackView {
     }
 
     /// Adds new view on top of the stack in the center of the screen.
-    pub fn add_layer<T>(&mut self, view: T)
+    pub fn add_layer<T>(&mut self, view: T, id: Option<&str>)
     where
         T: 'static + View,
     {
-        self.add_layer_at(Position::center(), view);
+        self.add_layer_at(Position::center(), view, id);
     }
 
     /// Adds new view on top of the stack in the center of the screen.
     ///
     /// Chainable variant.
-    pub fn layer<T>(self, view: T) -> Self
+    pub fn layer<T>(self, view: T, id: Option<&str>) -> Self
     where
         T: 'static + View,
     {
-        self.with(|s| s.add_layer(view))
+        self.with(|s| s.add_layer(view, id))
     }
 
     /// Adds a new full-screen layer on top of the stack.
     ///
     /// Chainable variant.
-    pub fn fullscreen_layer<T>(self, view: T) -> Self
+    pub fn fullscreen_layer<T>(self, view: T, id: Option<&str>) -> Self
     where
         T: 'static + View,
     {
-        self.with(|s| s.add_fullscreen_layer(view))
+        self.with(|s| s.add_fullscreen_layer(view, id))
     }
 
     /// Adds a view on top of the stack.
-    pub fn add_layer_at<T>(&mut self, position: Position, view: T)
+    pub fn add_layer_at<T>(&mut self, position: Position, view: T, id: Option<&str>)
     where
         T: 'static + View,
     {
         let boxed: Box<AnyView> = Box::new(view);
+        let id = match id {
+            Some(s) => Some(s.to_string()),
+            None => None,
+        };
         self.layers.push(Child {
             // Skip padding for absolute/parent-placed views
             view: ChildWrapper::Shadow(
@@ -212,6 +235,7 @@ impl StackView {
                     .top_padding(position.y == Offset::Center)
                     .left_padding(position.x == Offset::Center),
             ),
+            id: id ,
             size: Vec2::new(0, 0),
             placement: Placement::Floating(position),
             virgin: true,
@@ -221,11 +245,11 @@ impl StackView {
     /// Adds a view on top of the stack.
     ///
     /// Chainable variant.
-    pub fn layer_at<T>(self, position: Position, view: T) -> Self
+    pub fn layer_at<T>(self, position: Position, view: T, id: Option<&str>) -> Self
     where
         T: 'static + View,
     {
-        self.with(|s| s.add_layer_at(position, view))
+        self.with(|s| s.add_layer_at(position, view, id))
     }
 
     /// Remove the top-most layer.
@@ -282,6 +306,20 @@ impl StackView {
     /// Pushes the given view to the back of the stack.
     pub fn move_to_back(&mut self, layer: LayerPosition) {
         self.move_layer(layer, LayerPosition::FromBack(0));
+    }
+
+    /// Pushes the view with the given ID to the front of the stack
+    pub fn move_id_to_front(&mut self, id:&str) {
+        if let Some(p) = self.child_pos_with_view_id(id) {
+            self.move_layer(LayerPosition::FromBack(p), LayerPosition::FromFront(0));
+        }
+    }
+
+    /// Pushes the view with the given ID to the back of the stack
+    pub fn move_id_to_back(&mut self, id:&str) {
+        if let Some(p) = self.child_pos_with_view_id(id) {
+            self.move_layer(LayerPosition::FromBack(p), LayerPosition::FromBack(0));
+        }
     }
 
     /// Moves a layer to a new position on the screen.
@@ -479,9 +517,9 @@ mod tests {
     #[test]
     fn move_layer_works() {
         let mut stack = StackView::new()
-            .layer(TextView::new("1"))
-            .layer(TextView::new("2"))
-            .layer(TextView::new("3"));
+            .layer(TextView::new("1"), None)
+            .layer(TextView::new("2"), None)
+            .layer(TextView::new("3"), None);
 
         stack.move_layer(LayerPosition::FromFront(0), LayerPosition::FromBack(0));
         stack.move_layer(LayerPosition::FromBack(0), LayerPosition::FromFront(0));
@@ -491,5 +529,32 @@ mod tests {
         let box_view = layer.as_any().downcast_ref::<Box<AnyView>>().unwrap();
         let text_view = (**box_view).as_any().downcast_ref::<TextView>().unwrap();
         assert_eq!(text_view.get_content().source(), "2");
+    }
+
+    #[test]
+    fn move_by_id() {
+        let mut stack = StackView::new()
+            .layer(TextView::new("1"), Some("layer_1"))
+            .layer(TextView::new("2"), Some("layer_2"))
+            .layer(TextView::new("3"), Some("layer_3"));
+
+        stack.move_id_to_front("layer_2");
+
+        let layer = stack.pop_layer().unwrap();
+        let box_view = layer.as_any().downcast_ref::<Box<AnyView>>().unwrap();
+        let text_view = (**box_view).as_any().downcast_ref::<TextView>().unwrap();
+        assert_eq!(text_view.get_content().source(), "2");
+
+        stack.move_id_to_back("layer_2");
+
+        let layer = stack.pop_layer().unwrap();
+        let box_view = layer.as_any().downcast_ref::<Box<AnyView>>().unwrap();
+        let text_view = (**box_view).as_any().downcast_ref::<TextView>().unwrap();
+        assert_eq!(text_view.get_content().source(), "3");
+
+        let layer = stack.pop_layer().unwrap();
+        let box_view = layer.as_any().downcast_ref::<Box<AnyView>>().unwrap();
+        let text_view = (**box_view).as_any().downcast_ref::<TextView>().unwrap();
+        assert_eq!(text_view.get_content().source(), "1");
     }
 }


### PR DESCRIPTION
Hello, I'm trying to integrate Cursive into the Grin Cryptocurrency project (https://github.com/mimblewimble/grin), and am having difficulty trying to create a simple always-displayed menu that changes the content of another view onscreen. The issue is that there's no way to identify a stack view other than by position in the stack, which makes it cumbersome to relate a menu item to a particular stack view. 

I've forked off my own branch to include in the project, but it would be very good if this, (or something equivalent) could be included upstream. Basically, it changes the 'layer' function in StackView to include an optional id:

```
let stack = StackView::new()
   .layer("TextView::new("1"), Some("layer_1"))
   .layer("TextView::new("2"), Some("layer_2"))
   .layer("TextView::new("1"), Some("layer_3"))
```

And then layers can be brought to the front with:

```
   stack.move_id_to_front("layer_2");
```

etc.

Not offended if what I have here breaks any design principles, but I think this feature would be very good to include in some form or another. I'd originally tried to only include the ID in the Child struct based on whether the added view was wrapped in an IDView, but had trouble trying to downcast it generically to operate on it (I don't think it can be done in Rust), so unfortunately my approach required an additional Option argument to `layer` and related functions.

Thank you for your work so far on Cursive, it seems excellent.