### PR TITLE
Making `backend::Backend` into a `std::Box`able trait 

### DIFF
--- a/src/backend/blt.rs
+++ b/src/backend/blt.rs
@@ -175,7 +175,7 @@ impl backend::Backend for Concrete {
         let current = ColorPair {
             front: blt_colour_to_colour(state::foreground()),
             back:  blt_colour_to_colour(state::background())
-        }
+        };
         
         let fg = colour_to_blt_colour(color.front, ColorRole::Foreground);
         let bg = colour_to_blt_colour(color.back, ColorRole::Background);
@@ -202,7 +202,7 @@ impl backend::Backend for Concrete {
         }
     }
 
-    fn unset_effect(&self, effect: Effect) {
+    fn reset_effect(&self, effect: Effect) {
         match effect {
             // TODO: does BLT support bold/italic/underline?
             Effect::Bold

--- a/src/backend/blt.rs
+++ b/src/backend/blt.rs
@@ -202,7 +202,7 @@ impl backend::Backend for Concrete {
         }
     }
 
-    fn reset_effect(&self, effect: Effect) {
+    fn unset_effect(&self, effect: Effect) {
         match effect {
             // TODO: does BLT support bold/italic/underline?
             Effect::Bold

--- a/src/backend/curses/n.rs
+++ b/src/backend/curses/n.rs
@@ -236,7 +236,7 @@ impl backend::Backend for Concrete {
         ncurses::attron(style);
     }
 
-    fn reset_effect(&self, effect: Effect) {
+    fn unset_effect(&self, effect: Effect) {
         let style = match effect {
             Effect::Reverse => ncurses::A_REVERSE(),
             Effect::Simple => ncurses::A_NORMAL(),

--- a/src/backend/curses/pan.rs
+++ b/src/backend/curses/pan.rs
@@ -162,8 +162,8 @@ impl backend::Backend for Concrete {
             last_mouse_button: None,
             event_queue: Vec::new(),
             key_codes: initialize_keymap(),
-        }
-        
+        };
+
         Box::new(c)
     }
 

--- a/src/backend/curses/pan.rs
+++ b/src/backend/curses/pan.rs
@@ -133,7 +133,7 @@ impl Concrete {
 }
 
 impl backend::Backend for Concrete {
-    fn init() -> Self {
+    fn init() -> Box<Self> {
         ::std::env::set_var("ESCDELAY", "25");
 
         let window = pancurses::initscr();
@@ -155,7 +155,7 @@ impl backend::Backend for Concrete {
         print!("\x1B[?1002h");
         stdout().flush().expect("could not flush stdout");
 
-        Concrete {
+        let c = Concrete {
             current_style: Cell::new(ColorPair::from_256colors(0, 0)),
             pairs: RefCell::new(HashMap::new()),
             window: window,
@@ -163,6 +163,8 @@ impl backend::Backend for Concrete {
             event_queue: Vec::new(),
             key_codes: initialize_keymap(),
         }
+        
+        Box::new(c)
     }
 
     fn screen_size(&self) -> (usize, usize) {
@@ -180,21 +182,17 @@ impl backend::Backend for Concrete {
         pancurses::endwin();
     }
 
-    fn with_color<F: FnOnce()>(&self, colors: ColorPair, f: F) {
+    fn set_color(&self, colors: ColorPair) -> ColorPair {
         let current = self.current_style.get();
 
         if current != colors {
             self.set_colors(colors);
         }
 
-        f();
-
-        if current != colors {
-            self.set_colors(current);
-        }
+        current
     }
 
-    fn with_effect<F: FnOnce()>(&self, effect: Effect, f: F) {
+    fn set_effect(&self, effect: Effect) {
         let style = match effect {
             Effect::Simple => pancurses::Attribute::Normal,
             Effect::Reverse => pancurses::Attribute::Reverse,
@@ -203,7 +201,16 @@ impl backend::Backend for Concrete {
             Effect::Underline => pancurses::Attribute::Underline,
         };
         self.window.attron(style);
-        f();
+    }
+
+    fn reset_effect(&self, effect: Effect) {
+        let style = match effect {
+            Effect::Simple => pancurses::Attribute::Normal,
+            Effect::Reverse => pancurses::Attribute::Reverse,
+            Effect::Bold => pancurses::Attribute::Bold,
+            Effect::Italic => pancurses::Attribute::Italic,
+            Effect::Underline => pancurses::Attribute::Underline,
+        };
         self.window.attroff(style);
     }
 

--- a/src/backend/curses/pan.rs
+++ b/src/backend/curses/pan.rs
@@ -203,7 +203,7 @@ impl backend::Backend for Concrete {
         self.window.attron(style);
     }
 
-    fn reset_effect(&self, effect: Effect) {
+    fn unset_effect(&self, effect: Effect) {
         let style = match effect {
             Effect::Simple => pancurses::Attribute::Normal,
             Effect::Reverse => pancurses::Attribute::Reverse,

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -35,8 +35,10 @@ pub trait Backend {
 
     fn set_refresh_rate(&mut self, fps: u32);
 
+    // This sets the Colours and returns the previous colours
+    // to allow you to set them back when you're done.
     fn set_color(&self, colors: theme::ColorPair) -> theme::ColorPair;
 
     fn set_effect(&self, effect: theme::Effect);
-    fn reset_effect(&self, effect: theme::Effect);
+    fn unset_effect(&self, effect: theme::Effect);
 }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -16,7 +16,7 @@ pub use self::curses::*;
 pub use self::termion::*;
 
 pub trait Backend {
-    fn init() -> Self;
+    fn init() -> Box<Self> where Self: Sized;
     // TODO: take `self` by value?
     // Or implement Drop?
     fn finish(&mut self);
@@ -34,7 +34,9 @@ pub trait Backend {
     fn clear(&self, color: theme::Color);
 
     fn set_refresh_rate(&mut self, fps: u32);
-    // TODO: unify those into a single method?
-    fn with_color<F: FnOnce()>(&self, colors: theme::ColorPair, f: F);
-    fn with_effect<F: FnOnce()>(&self, effect: theme::Effect, f: F);
+
+    fn set_color(&self, colors: theme::ColorPair) -> theme::ColorPair;
+
+    fn set_effect(&self, effect: theme::Effect);
+    fn reset_effect(&self, effect: theme::Effect);
 }

--- a/src/backend/termion.rs
+++ b/src/backend/termion.rs
@@ -179,7 +179,7 @@ impl backend::Backend for Concrete {
         );
     }
 
-    fn with_color<F: FnOnce()>(&self, color: theme::ColorPair, f: F) -> theme::ColorPair {
+    fn set_color(&self, color: theme::ColorPair) -> theme::ColorPair {
         let current_style = self.current_style.get();
 
         if current_style != color {

--- a/src/backend/termion.rs
+++ b/src/backend/termion.rs
@@ -194,7 +194,7 @@ impl backend::Backend for Concrete {
         effect.on();
     }
 
-    fn reset_effect(&self, effect: theme::Effect) {
+    fn unset_effect(&self, effect: theme::Effect) {
         effect.off();
     }
 

--- a/src/cursive.rs
+++ b/src/cursive.rs
@@ -54,7 +54,7 @@ pub struct Cursive {
 
     running: bool,
 
-    backend: backend::Concrete,
+    backend: Box<backend::Backend>,
 
     cb_source: mpsc::Receiver<Box<CbFunc>>,
     cb_sink: mpsc::Sender<Box<CbFunc>>,

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -1,6 +1,6 @@
 //! Makes drawing on ncurses windows easier.
 
-use backend::{self, Backend};
+use backend::Backend;
 use enumset::EnumSet;
 use std::cell::Cell;
 use std::cmp::min;
@@ -24,7 +24,7 @@ pub struct Printer<'a> {
     /// `true` if nothing has been drawn yet.
     new: Rc<Cell<bool>>,
     /// Backend used to actually draw things
-    backend: &'a Box<backend::Backend>,
+    backend: &'a Box<Backend>,
 }
 
 impl<'a> Printer<'a> {
@@ -33,7 +33,7 @@ impl<'a> Printer<'a> {
     /// But nobody needs to know that.
     #[doc(hidden)]
     pub fn new<T: Into<Vec2>>(
-        size: T, theme: &'a Theme, backend: &'a Box<backend::Backend>
+        size: T, theme: &'a Theme, backend: &'a Box<Backend>
     ) -> Self {
         Printer {
             offset: Vec2::zero(),
@@ -121,7 +121,7 @@ impl<'a> Printer<'a> {
     /// # use cursive::Printer;
     /// # use cursive::theme;
     /// # use cursive::backend::{self, Backend};
-    /// # let b = backend::Concrete::init();
+    /// # let b: Box<Backend> = backend::Concrete::init();
     /// # let t = theme::load_default();
     /// # let printer = Printer::new((6,4), &t, &b);
     /// printer.with_color(theme::ColorStyle::highlight(), |printer| {
@@ -199,7 +199,7 @@ impl<'a> Printer<'a> {
     /// # use cursive::Printer;
     /// # use cursive::theme;
     /// # use cursive::backend::{self, Backend};
-    /// # let b = backend::Concrete::init();
+    /// # let b: Box<Backend> = backend::Concrete::init();
     /// # let t = theme::load_default();
     /// # let printer = Printer::new((6,4), &t, &b);
     /// printer.print_box((0,0), (6,4), false);

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -168,7 +168,7 @@ impl<'a> Printer<'a> {
     {
         self.backend.set_effect(effect);
         f(self);
-        self.backend.reset_effect(effect);
+        self.backend.unset_effect(effect);
     }
 
     /// Call the given closure with a modified printer

--- a/src/view/scroll.rs
+++ b/src/view/scroll.rs
@@ -232,7 +232,7 @@ impl ScrollBase {
     /// # use cursive::theme;
     /// # use cursive::backend::{self, Backend};
     /// # let scrollbase = ScrollBase::new();
-    /// # let b = backend::Concrete::init();
+    /// # let b: Box<Backend> = backend::Concrete::init();
     /// # let t = theme::load_default();
     /// # let printer = Printer::new((5,1), &t, &b);
     /// # let printer = &printer;


### PR DESCRIPTION
# Summary
[summary]: #summary

This PR modifies the `Backend` trait and its accompanying `Concrete` implementations to support boxing the trait into a trait object, and modifying the `Cursive` and `Printer` objects to use this boxed trait.

# Motivation
[motivation]: #motivation

The existing `Printer` and `Cursive` implementations are hardcoded to use the `backend::Concrete` backend implementation. This causes no issues for the users of the Cursive library, but 3rd party developers (like me) wishing to embed Cursive into other frameworks cannot replace the Concrete implementation with their own backend.

This PR allows two major changes for 3rd party developers:
  * They can create structs that contain `Box<backend::Backend>` fields that can be populated with a backend at runtime.
  * Custom Backends can be passed to `Printer` allowing Cursive to be used with custom backends.

# Drawbacks
[drawbacks]: #drawbacks

  * Instantiating printers is now slightly more complicated. 
  * Breaking Change to backend API - All implementors have been updated.
  * Backend trait is now usable outside of library, so should be semantically versioned, from here out.

# Side-effects 

- Reverse Video Effect in BLT has been fixed and now supports color