### PR TITLE
Don't require num default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,13 +17,16 @@ repository = "gyscos/Cursive"
 enum-map = "0.2.24"
 enumset = "0.3.3"
 log = "0.4"
-num = "0.1"
 owning_ref = "0.3.3"
 toml = "0.4"
 unicode-segmentation = "1.0"
 unicode-width = "0.1"
 xi-unicode = "0.1.0"
 libc = "0.2"
+
+[dependencies.num]
+default-features = false
+version = "0.1"
 
 [dependencies.maplit]
 optional = true


### PR DESCRIPTION
The num crate's default features pull in some extra stuff which isn't used by Cursive. Most notably, rustc-serialize, which prevents compiling to wasm.