### PR TITLE
Fix broken example in readme to use Cursive::default()

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -37,7 +37,7 @@ use cursive::views::{Dialog, TextView};
 
 fn main() {
     // Creates the cursive root - required for every application.
-    let mut siv = Cursive::ncurses();
+    let mut siv = Cursive::default();
 
     // Creates a dialog with a single "Quit" button
     siv.add_layer(Dialog::around(TextView::new("Hello Dialog!"))

--- a/Readme.md
+++ b/Readme.md
@@ -37,7 +37,7 @@ use cursive::views::{Dialog, TextView};
 
 fn main() {
     // Creates the cursive root - required for every application.
-    let mut siv = Cursive::new();
+    let mut siv = Cursive::ncurses();
 
     // Creates a dialog with a single "Quit" button
     siv.add_layer(Dialog::around(TextView::new("Hello Dialog!"))


### PR DESCRIPTION
Hi.
I just found out about this library and the first thing I did was to read the readme, create a new project and try the example. I was met with this error:
```rust
error[E0061]: this function takes 1 parameter but 0 parameters were supplied
 --> src/main.rs:8:19
  |
8 |     let mut siv = Cursive::new();
  |                   ^^^^^^^^^^^^^^ expected 1 parameter
```
I read the docs and switched the example to use `Cursive::ncurses()` instead. This should help new users like me and provide them with a smooth introduction into the library.