### PR TITLE
Fix crash when removing the final child from LinearLayout when that child has focus

### DIFF
--- a/src/views/linear_layout.rs
+++ b/src/views/linear_layout.rs
@@ -192,7 +192,7 @@ impl LinearLayout {
         if i < self.children.len() {
             self.invalidate();
 
-            if self.focus > i {
+            if self.focus > i || (self.focus != 0 && self.focus == self.children.len() - 1) {
                 self.focus -= 1;
             }
             Some(self.children.remove(i).view)


### PR DESCRIPTION
If the last child was focused in a linear layout and that child is removed, the focused index will be past the end of the array. The next time the user tried to navigate (by pressing an arrow key for example), the application crashes. Here is the relevant line from the backtrace:
  10: <cursive::views::linear_layout::LinearLayout as cursive::view::view::View>::on_event
             at /home/ben/.cargo/registry/src/github.com-1ecc6299db9ec823/cursive-0.9.0/src/views/linear_layout.rs:544

This patch prevents the crash by keeping the focused index in bounds when remove_child is called.

(I can't get rustfmt to build on my computer, sorry)