### PR TITLE
Do not compile signal_hook on Windows

### DIFF
--- a/src/backend/termion.rs
+++ b/src/backend/termion.rs
@@ -16,6 +16,8 @@ use self::termion::screen::AlternateScreen;
 use self::termion::style as tstyle;
 use crossbeam_channel::{self, Receiver, Sender};
 use libc;
+
+#[cfg(unix)]
 use signal_hook::iterator::Signals;
 
 use backend;


### PR DESCRIPTION
Fixes #294 