### PR TITLE
Bump `bear-lib-terminal` version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ version = "1.0"
 
 [dependencies.bear-lib-terminal]
 optional = true
-version = "1.4"
+version = "2.0"
 
 [dependencies.ncurses]
 features = ["wide"]


### PR DESCRIPTION
There is a new major release of `bear-lib-terminal` which I think was motivated by a small (but technically breaking) change I requested (<https://github.com/nabijaczleweli/BearLibTerminal.rs/pull/8>). Anyway, just bumping the version to 2.0 seems to work alright.