### PR TITLE
Add Backend::print_at_rep and make Printer::print_hline use it.

### DIFF
--- a/src/backend/blt.rs
+++ b/src/backend/blt.rs
@@ -314,7 +314,7 @@ impl backend::Backend for Backend {
 
     fn print_at_rep(&self, pos: Vec2, repetitions: usize, text: &str) {
         if repetitions > 0 {
-            let width: i32 = text.width().into();
+            let width: i32 = text.width() as i32;
             
             let mut pos_x = pos.x as i32;
             let pos_y = pos.y as i32;

--- a/src/backend/blt.rs
+++ b/src/backend/blt.rs
@@ -312,24 +312,6 @@ impl backend::Backend for Backend {
         terminal::print_xy(pos.x as i32, pos.y as i32, text);
     }
 
-    fn print_at_rep(&self, pos: Vec2, repetitions: usize, text: &str) {
-        if repetitions > 0 {
-            let width: i32 = text.width() as i32;
-            
-            let mut pos_x = pos.x as i32;
-            let pos_y = pos.y as i32;
-            let mut dupes_left = repetitions - 1;
-            
-            terminal::print_xy(pos_x, pos_y, text);
-            
-            while dupes_left > 0 {
-                pos_x += width;
-                terminal::print_xy(pos_x, pos_y, text);
-                dupes_left -= 1;
-            }
-        }
-    }
-
     fn poll_event(&mut self) -> Option<Event> {
         self.parse_next()
     }

--- a/src/backend/blt.rs
+++ b/src/backend/blt.rs
@@ -18,7 +18,6 @@ use crate::event::{Event, Key, MouseButton, MouseEvent};
 use crate::theme::{BaseColor, Color, ColorPair, Effect};
 use crate::vec::Vec2;
 use unicode_width::UnicodeWidthStr;
-use std::convert::TryInto;
 
 enum ColorRole {
     Foreground,
@@ -315,9 +314,7 @@ impl backend::Backend for Backend {
 
     fn print_at_rep(&self, pos: Vec2, repetitions: usize, text: &str) {
         if repetitions > 0 {
-            let width: i32 = text.width().try_into().expect(
-                "Cannot repeatedly print text that is too wide (in characters) \
-                to be described by a 32-bit signed integer.");
+            let width: i32 = text.width().into();
             
             let mut pos_x = pos.x as i32;
             let pos_y = pos.y as i32;

--- a/src/backend/curses/n.rs
+++ b/src/backend/curses/n.rs
@@ -373,6 +373,17 @@ impl backend::Backend for Backend {
     fn print_at(&self, pos: Vec2, text: &str) {
         ncurses::mvaddstr(pos.y as i32, pos.x as i32, text);
     }
+
+    fn print_at_rep(&self, pos: Vec2, repetitions: usize, text: &str) {
+        if repetitions > 0 {
+            ncurses::mvaddstr(pos.y as i32, pos.x as i32, text);
+            let mut dupes_left = repetitions - 1;
+            while dupes_left > 0 {
+                ncurses::addstr(text);
+                dupes_left -= 1;
+            }
+        }
+    }
 }
 
 /// Returns the Key enum corresponding to the given ncurses event.

--- a/src/backend/curses/pan.rs
+++ b/src/backend/curses/pan.rs
@@ -417,6 +417,17 @@ impl backend::Backend for Backend {
         self.window.mvaddstr(pos.y as i32, pos.x as i32, text);
     }
 
+    fn print_at_rep(&self, pos: Vec2, repetitions: usize, text: &str) {
+        if repetitions > 0 {
+            self.window.mvaddstr(pos.y as i32, pos.x as i32, text);
+            let mut dupes_left = repetitions - 1;
+            while dupes_left > 0 {
+                self.window.addstr(text);
+                dupes_left -= 1;
+            }
+        }
+    }
+
     fn poll_event(&mut self) -> Option<Event> {
         self.parse_next()
     }

--- a/src/backend/dummy.rs
+++ b/src/backend/dummy.rs
@@ -38,6 +38,8 @@ impl backend::Backend for Backend {
 
     fn print_at(&self, _: Vec2, _: &str) {}
 
+    fn print_at_rep(&self, pos: Vec2, repetitions: usize, text: &str) {}
+
     fn clear(&self, _: theme::Color) {}
 
     // This sets the Colours and returns the previous colours

--- a/src/backend/dummy.rs
+++ b/src/backend/dummy.rs
@@ -38,7 +38,7 @@ impl backend::Backend for Backend {
 
     fn print_at(&self, _: Vec2, _: &str) {}
 
-    fn print_at_rep(&self, pos: Vec2, repetitions: usize, text: &str) {}
+    fn print_at_rep(&self, _pos: Vec2, _repetitions: usize, _text: &str) {}
 
     fn clear(&self, _: theme::Color) {}
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -63,6 +63,10 @@ pub trait Backend {
 
     /// Main method used for printing
     fn print_at(&self, pos: Vec2, text: &str);
+    
+    /// First positions the cursor, similar to `print_at`, and then prints the given number of
+    /// `repetitions` of `text`.
+    fn print_at_rep(&self, pos: Vec2, repetitions: usize, text: &str);
 
     /// Clears the screen with the given color.
     fn clear(&self, color: theme::Color);

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -10,6 +10,7 @@
 use crate::event::Event;
 use crate::theme;
 use crate::vec::Vec2;
+use unicode_width::UnicodeWidthStr;
 
 #[cfg(unix)]
 mod resize;
@@ -66,7 +67,21 @@ pub trait Backend {
     
     /// First positions the cursor, similar to `print_at`, and then prints the given number of
     /// `repetitions` of `text`.
-    fn print_at_rep(&self, pos: Vec2, repetitions: usize, text: &str);
+    fn print_at_rep(&self, pos: Vec2, repetitions: usize, text: &str) {
+        if repetitions > 0 {
+            self.print_at(pos, text);
+
+            let width = text.width();
+            let mut pos = pos;
+            let mut dupes_left = repetitions - 1;
+
+            while dupes_left > 0 {
+                pos = pos.saturating_add((width, 0));
+                self.print_at(pos, text);
+                dupes_left -= 1;
+            }
+        }
+    }
 
     /// Clears the screen with the given color.
     fn clear(&self, color: theme::Color);

--- a/src/backend/termion.rs
+++ b/src/backend/termion.rs
@@ -268,6 +268,24 @@ impl backend::Backend for Backend {
         .unwrap();
     }
 
+    fn print_at_rep(&self, pos: Vec2, repetitions: usize, text: &str) {
+        if repetitions > 0 {
+            let mut out = self.terminal.borrow_mut();
+            write!(
+                out,
+                "{}{}",
+                termion::cursor::Goto(1 + pos.x as u16, 1 + pos.y as u16),
+                text
+            ).unwrap();
+            
+            let mut dupes_left = repetitions - 1;
+            while dupes_left > 0 {
+                write!(out, "{}", text).unwrap();
+                dupes_left -= 1;
+            }
+        }
+    }
+
     fn poll_event(&mut self) -> Option<Event> {
         let event = select! {
             recv(self.input_receiver) -> event => event.ok(),

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -246,7 +246,7 @@ impl<'a, 'b> Printer<'a, 'b> {
         let start = start - self.content_offset;
 
         // Don't write too much if we're close to the end
-        let repetitions = min(width, (self.output_size.x - start.x)) / c.width();
+        let repetitions = min(width, self.output_size.x - start.x) / c.width();
 
         let start = start + self.offset;
         self.backend.print_at_rep(start, repetitions, c);

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -248,11 +248,8 @@ impl<'a, 'b> Printer<'a, 'b> {
         // Don't write too much if we're close to the end
         let width = min(width, (self.output_size.x - start.x) / c.width());
 
-        // Could we avoid allocating?
-        let text: String = ::std::iter::repeat(c).take(width).collect();
-
         let start = start + self.offset;
-        self.backend.print_at(start, &text);
+        self.backend.print_at_rep(start, width, &c);
     }
 
     /// Call the given closure with a colored printer,

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -246,10 +246,10 @@ impl<'a, 'b> Printer<'a, 'b> {
         let start = start - self.content_offset;
 
         // Don't write too much if we're close to the end
-        let width = min(width, (self.output_size.x - start.x) / c.width());
+        let repetitions = min(width, (self.output_size.x - start.x)) / c.width();
 
         let start = start + self.offset;
-        self.backend.print_at_rep(start, width, &c);
+        self.backend.print_at_rep(start, repetitions, c);
     }
 
     /// Call the given closure with a colored printer,


### PR DESCRIPTION
This avoids a string allocation in `print_hline` and makes it faster, presumably for all backends.
This speeds up the rendering of the background in StackView.

This supersedes #324, since it not only looks simpler when each backend is taken in isolation, but also appears to make the rendering even faster.