### PR TITLE
Add a sort method to SelectView, to easily sort all contained items lexicographically by their label.

### DIFF
--- a/src/views/select_view.rs
+++ b/src/views/select_view.rs
@@ -389,7 +389,7 @@ impl<T: 'static> SelectView<T> {
     /// Note that this does not change the current focus index, which means that the current
     /// selection will likely be changed by the sorting.
     /// This sort is stable: items with identical label will not be reordered.
-    pub fn sort(&mut self) {
+    pub fn sort_by_label(&mut self) {
         self.items.sort();
     }
     
@@ -848,7 +848,7 @@ mod tests {
         view.add_item_str("X");
 
         // Then sorting the list...
-        view.sort();
+        view.sort_by_label();
 
         // ... should observe the items in sorted order.
         // And focus is NOT changed by the sorting, so the first item is "X".

--- a/src/views/select_view.rs
+++ b/src/views/select_view.rs
@@ -390,7 +390,7 @@ impl<T: 'static> SelectView<T> {
     /// selection will likely be changed by the sorting.
     /// This sort is stable: items with identical label will not be reordered.
     pub fn sort_by_label(&mut self) {
-        self.items.sort();
+        self.items.sort_by(|a, b| a.label.source().cmp(b.label.source()));
     }
     
     /// Sort the current items with the given comparator function.
@@ -811,27 +811,6 @@ impl<T> Item<T> {
     fn new(label: StyledString, value: T) -> Self {
         let value = Rc::new(value);
         Item { label, value }
-    }
-}
-
-impl<T> PartialEq for Item<T> {
-    fn eq(&self, other: &Self) -> bool {
-        self.label.source().eq(other.label.source())
-    }
-}
-
-impl<T> Eq for Item<T> {
-}
-
-impl<T> PartialOrd for Item<T> {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.label.source().partial_cmp(other.label.source())
-    }
-}
-
-impl<T> Ord for Item<T> {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.label.source().cmp(other.label.source())
     }
 }
 


### PR DESCRIPTION
I was populating a `SelectView` with files from `read_dir`, which returns them in whatever order the OS feels like, and thought it'd be convenient if I could just tell the `SelectView` to sort itself.

I tried to use `Vec::sort_by_key` at first, but apparently the lifetimes around the closure got too complicated for me to deal with, so I implemented `Ord` (and friends it insisted on bringing along) for `Item` instead.