### PR TITLE
[PAN] Interprete 'carriage return' as 'enter'

### DIFF
--- a/src/backend/curses/pan.rs
+++ b/src/backend/curses/pan.rs
@@ -135,7 +135,8 @@ impl Backend {
 
         if let Some(ev) = self.window.getch() {
             Some(match ev {
-                pancurses::Input::Character('\n') => Event::Key(Key::Enter),
+                pancurses::Input::Character('\n')
+                | pancurses::Input::Character('\r') => Event::Key(Key::Enter),
                 // TODO: wait for a very short delay. If more keys are
                 // pipelined, it may be an escape sequence.
                 pancurses::Input::Character('\u{7f}')


### PR DESCRIPTION
Pancurses returns different key codes for "Enter" in the normal area
('\r'), and the one in the numpad ('\n'). Cursive only interpretes '\n'
as Enter, and leaves '\r' as CtrlChar('m'), which is different than
that with NCurses on Linux, and makes 'Enter' key not trigger a clicked
event on the button.