### PR TITLE
replace CbFunc with Box<FnOnce()>

### DIFF
--- a/examples/vpv.rs
+++ b/examples/vpv.rs
@@ -137,7 +137,7 @@ cargo run --example vpv </dev/zero >/dev/null",
             }
 
             // When we're done, shut down the application
-            cb_sink.send(Box::new(|s: &mut Cursive| s.quit())).unwrap();
+            cb_sink.send(Box::new(Cursive::quit)).unwrap();
         });
         siv.set_autorefresh(true);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,7 @@ mod utf8;
 
 pub mod backend;
 
-pub use self::cursive::{CbFunc, CbSink, Cursive, ScreenId};
+pub use self::cursive::{CbSink, Cursive, ScreenId};
 pub use self::printer::Printer;
 pub use self::rect::Rect;
 pub use self::vec::Vec2;


### PR DESCRIPTION
Since Rust 1.35, Box<FnOnce()> compiles, we can remove the workaround.

This is a breaking change, version bump will be necessary, but it's more convenient to use,
closures without explicit argument types will work. (You can write `|s| s.quit` or `Cursive::quit` instead of `|s: &mut Cursive| s.quit()`)