### PR TITLE
Add getters for current and max value in SliderView

### DIFF
--- a/src/views/slider_view.rs
+++ b/src/views/slider_view.rs
@@ -63,6 +63,16 @@ impl SliderView {
         })
     }
 
+    /// Gets the current value.
+    pub fn get_value(&self) -> usize {
+        self.value
+    }
+
+    /// Gets the max value.
+    pub fn get_max_value(&self) -> usize {
+        self.max_value
+    }
+
     /// Sets a callback to be called when the slider is moved.
     pub fn on_change<F>(mut self, callback: F) -> Self
     where


### PR DESCRIPTION
I'm working on a toy example to learn Cursive. It includes a dialog box with a bunch of sliders, with an OK button to check to see if the user set the sliders to the right positions to "crack" the code. However, I need to be able to get the values of the sliders upon hitting OK, and I found no way to do that. I added two methods to `SliderView` to help with this: `get_value` and `get_max_value`.