### PR TITLE
Add strikethrough effect

### DIFF
--- a/src/backend/blt.rs
+++ b/src/backend/blt.rs
@@ -261,10 +261,11 @@ impl backend::Backend for Backend {
 
     fn set_effect(&self, effect: Effect) {
         match effect {
-            // TODO: does BLT support bold/italic/underline?
+            // TODO: does BLT support bold/italic/strikethrough/underline?
             Effect::Bold
             | Effect::Italic
             | Effect::Underline
+            | Effect::Strikethrough
             | Effect::Simple => {}
             // TODO: how to do this correctly?`
             //       BLT itself doesn't do this kind of thing,
@@ -278,10 +279,11 @@ impl backend::Backend for Backend {
 
     fn unset_effect(&self, effect: Effect) {
         match effect {
-            // TODO: does BLT support bold/italic/underline?
+            // TODO: does BLT support bold/italic/strikethrough/underline?
             Effect::Bold
             | Effect::Italic
             | Effect::Underline
+            | Effect::Strikethrough
             | Effect::Simple => {}
             // The process of reversing is the same as unreversing
             Effect::Reverse => {

--- a/src/backend/crossterm.rs
+++ b/src/backend/crossterm.rs
@@ -234,6 +234,7 @@ impl backend::Backend for Backend {
             theme::Effect::Reverse => self.write(Attribute::Reverse),
             theme::Effect::Bold => self.write(Attribute::Bold),
             theme::Effect::Italic => self.write(Attribute::Italic),
+            theme::Effect::Strikethrough => self.write(Attribute::CrossedOut),
             theme::Effect::Underline => self.write(Attribute::Underlined),
         }
     }
@@ -244,6 +245,7 @@ impl backend::Backend for Backend {
             theme::Effect::Reverse => self.write(Attribute::Reverse),
             theme::Effect::Bold => self.write(Attribute::NoBold),
             theme::Effect::Italic => self.write(Attribute::NoItalic),
+            theme::Effect::Strikethrough => self.write(Attribute::NotCrossedOut),
             theme::Effect::Underline => self.write(Attribute::Underlined),
         }
     }

--- a/src/backend/curses/n.rs
+++ b/src/backend/curses/n.rs
@@ -343,7 +343,7 @@ impl backend::Backend for Backend {
             Effect::Simple => ncurses::A_NORMAL(),
             Effect::Bold => ncurses::A_BOLD(),
             Effect::Italic => ncurses::A_ITALIC(),
-            Effect::Strikethrough => {},
+            Effect::Strikethrough => ncurses::A_NORMAL(),
             Effect::Underline => ncurses::A_UNDERLINE(),
         };
         ncurses::attron(style);
@@ -355,7 +355,7 @@ impl backend::Backend for Backend {
             Effect::Simple => ncurses::A_NORMAL(),
             Effect::Bold => ncurses::A_BOLD(),
             Effect::Italic => ncurses::A_ITALIC(),
-            Effect::Strikethrough => {},
+            Effect::Strikethrough => ncurses::A_NORMAL(),
             Effect::Underline => ncurses::A_UNDERLINE(),
         };
         ncurses::attroff(style);

--- a/src/backend/curses/n.rs
+++ b/src/backend/curses/n.rs
@@ -343,6 +343,7 @@ impl backend::Backend for Backend {
             Effect::Simple => ncurses::A_NORMAL(),
             Effect::Bold => ncurses::A_BOLD(),
             Effect::Italic => ncurses::A_ITALIC(),
+            Effect::Strikethrough => {},
             Effect::Underline => ncurses::A_UNDERLINE(),
         };
         ncurses::attron(style);
@@ -354,6 +355,7 @@ impl backend::Backend for Backend {
             Effect::Simple => ncurses::A_NORMAL(),
             Effect::Bold => ncurses::A_BOLD(),
             Effect::Italic => ncurses::A_ITALIC(),
+            Effect::Strikethrough => {},
             Effect::Underline => ncurses::A_UNDERLINE(),
         };
         ncurses::attroff(style);

--- a/src/backend/curses/pan.rs
+++ b/src/backend/curses/pan.rs
@@ -388,6 +388,7 @@ impl backend::Backend for Backend {
             Effect::Reverse => pancurses::Attribute::Reverse,
             Effect::Bold => pancurses::Attribute::Bold,
             Effect::Italic => pancurses::Attribute::Italic,
+            Effect::Strikethrough => pancurses::Attribute::Strikeout,
             Effect::Underline => pancurses::Attribute::Underline,
         };
         self.window.attron(style);
@@ -399,6 +400,7 @@ impl backend::Backend for Backend {
             Effect::Reverse => pancurses::Attribute::Reverse,
             Effect::Bold => pancurses::Attribute::Bold,
             Effect::Italic => pancurses::Attribute::Italic,
+            Effect::Strikethrough => pancurses::Attribute::Strikeout,
             Effect::Underline => pancurses::Attribute::Underline,
         };
         self.window.attroff(style);

--- a/src/backend/termion.rs
+++ b/src/backend/termion.rs
@@ -223,6 +223,7 @@ impl backend::Backend for Backend {
             theme::Effect::Reverse => self.write(tstyle::Invert),
             theme::Effect::Bold => self.write(tstyle::Bold),
             theme::Effect::Italic => self.write(tstyle::Italic),
+            theme::Effect::Strikethrough => self.write(tstyle::CrossedOut),
             theme::Effect::Underline => self.write(tstyle::Underline),
         }
     }
@@ -233,6 +234,7 @@ impl backend::Backend for Backend {
             theme::Effect::Reverse => self.write(tstyle::NoInvert),
             theme::Effect::Bold => self.write(tstyle::NoBold),
             theme::Effect::Italic => self.write(tstyle::NoItalic),
+            theme::Effect::Strikethrough => self.write(tstyle::NoCrossedOut),
             theme::Effect::Underline => self.write(tstyle::NoUnderline),
         }
     }

--- a/src/theme/effect.rs
+++ b/src/theme/effect.rs
@@ -11,6 +11,8 @@ pub enum Effect {
     Bold,
     /// Prints foreground in italic
     Italic,
+    /// Prints foreground with strikethrough
+    Strikethrough,
     /// Prints foreground with underline
     Underline,
 }


### PR DESCRIPTION
Adds a strikethrough effect that works with termion, pancurses, and crossterm backends. For ncurses and bear_lib_terminal it does nothing.