### PR TITLE
Change `TitleSecondary` from Yellow to Light Blue

### DIFF
--- a/src/theme/palette.rs
+++ b/src/theme/palette.rs
@@ -161,7 +161,7 @@ impl Default for Palette {
                 Secondary => Dark(Blue),
                 Tertiary => Dark(White),
                 TitlePrimary => Dark(Red),
-                TitleSecondary => Dark(Yellow),
+                TitleSecondary => Light(Blue),
                 Highlight => Dark(Red),
                 HighlightInactive => Dark(Blue),
             },


### PR DESCRIPTION
Hi,
I've recently played around with themes in cursive and noticed that in many commonly used themes the `TitleSecondary` color currently used is hard to distinguish from either `TitlePrimary` or `View` colors.

The current palette defaults sets `TitleSecondary` to a dark yellow:

```
Background => Dark(Blue),
Shadow => Dark(Black),
View => Dark(White),
Primary => Dark(Black),
Secondary => Dark(Blue),
Tertiary => Dark(White),
TitlePrimary => Dark(Red),
TitleSecondary => Dark(Yellow),
Highlight => Dark(Red),
HighlightInactive => Dark(Blue),
```
This results in looks similar to these:
#####  XTerm
![xterm_not_bright](https://user-images.githubusercontent.com/23524191/64479287-07b37d00-d1b5-11e9-9362-b4e25a4d7173.png)
Making it hard to read the complete text at first glance because the bright color of the text on a bright background.
##### Rxvt
![rxvt](https://user-images.githubusercontent.com/23524191/64479290-19952000-d1b5-11e9-8ed0-13a24f31fdb4.png)

Same for Rxvt.

##### Tango
![tango_not_bright](https://user-images.githubusercontent.com/23524191/64479294-1f8b0100-d1b5-11e9-834c-16bab971093d.png)

The variance between both is not that large. If we enable now bold text as bright text the behaviour is not that different, we still might have issues differentiating text from background without a closer look.

##### XTerm
![XTerm](https://user-images.githubusercontent.com/23524191/64479367-8b219e00-d1b6-11e9-9dba-8dd26ce421b2.png)
 
##### Rxvt
![Rxvt](https://user-images.githubusercontent.com/23524191/64479369-94126f80-d1b6-11e9-9179-519b0e49373d.png)

##### Tango
![Tango](https://user-images.githubusercontent.com/23524191/64479370-996fba00-d1b6-11e9-9c38-a0402f63362a.png)

For this PR I have changed the used color in the default palette to a light blue, for one to increase the difference of color to  `TitlePrimary` and `View` and to use a color otherwise not occupied in the current default palette.

#### Comparison with light blue:

##### XTerm
![blue_xterm_non](https://user-images.githubusercontent.com/23524191/64479804-937cd780-d1bc-11e9-9fdc-d1e284080e48.png)

##### Rxvt
![blue_rxvt_no](https://user-images.githubusercontent.com/23524191/64479805-9677c800-d1bc-11e9-9ab4-ead141cf18d9.png)

##### Tango
![blue_tango_non](https://user-images.githubusercontent.com/23524191/64479808-9ed00300-d1bc-11e9-81c1-1cc10fccbca1.png)

And with bold as bright text active:
##### XTerm
![blue_xterm](https://user-images.githubusercontent.com/23524191/64479811-a2fc2080-d1bc-11e9-82e0-c2e84e39e05d.png)

##### Rxvt
![blue_urxvt](https://user-images.githubusercontent.com/23524191/64479812-a5f71100-d1bc-11e9-8acb-80cd5c6f0595.png)

##### Tango
![blue_tango](https://user-images.githubusercontent.com/23524191/64479814-b3140000-d1bc-11e9-97d1-85b9ec27c4f3.png)
