### PR TITLE
Allow SelectView::with_all to accept StyledString

### DIFF
--- a/src/views/select_view.rs
+++ b/src/views/select_view.rs
@@ -343,7 +343,7 @@ impl<T: 'static> SelectView<T> {
     /// Chainable variant.
     pub fn with_all<S, I>(self, iter: I) -> Self
     where
-        S: Into<String>,
+        S: Into<StyledString>,
         I: IntoIterator<Item = (S, T)>,
     {
         self.with(|s| s.add_all(iter))


### PR DESCRIPTION
Changes the bound on the iterator items from `Into<String>` to `Into<StyledString>`.

This brings the API in line with the other item methods,
which all use the same bound.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gyscos/cursive/385)
<!-- Reviewable:end -->
