### PR TITLE
Change lazy_static version specifier to 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ xi-unicode = "0.2.0"
 libc = "0.2.60"
 term_size = { version = "0.3.1", optional = true }
 crossbeam-channel = "0.3.9"
-lazy_static = "1.3.0"
+lazy_static = "1"
 chrono = "0.4.7"
 cfg-if = "0.1.9"
 ahash = "0.2.12"


### PR DESCRIPTION
This allows cursive to be used together with libraries that pin the
`lazy_static` dependency to a version below 1.3.