### PR TITLE
crossterm: Stop mouse mode and show cursor at finish

### DIFF
--- a/src/backend/crossterm.rs
+++ b/src/backend/crossterm.rs
@@ -7,10 +7,10 @@
 use crate::vec::Vec2;
 use crate::{backend, theme};
 use crossterm::{
-    cursor, execute, input, queue, terminal, AlternateScreen, AsyncReader,
-    Attribute, Clear, ClearType, Color, Goto, InputEvent as CInputEvent,
+    cursor, input, queue, terminal, AlternateScreen, AsyncReader, Attribute,
+    Clear, ClearType, Color, Goto, InputEvent as CInputEvent,
     KeyEvent as CKeyEvent, MouseButton as CMouseButton,
-    MouseEvent as CMouseEvent, SetAttr, SetBg, SetFg, Show, Terminal,
+    MouseEvent as CMouseEvent, SetAttr, SetBg, SetFg, Terminal,
 };
 
 use crate::event::{Event, Key, MouseButton, MouseEvent};
@@ -173,17 +173,8 @@ impl backend::Backend for Backend {
     }
 
     fn finish(&mut self) {
-        execute!(
-            self.stdout.borrow_mut(),
-            Goto(0, 0),
-            Clear(ClearType::All),
-            SetBg(Color::Reset),
-            SetFg(Color::Reset),
-            SetAttr(Attribute::Reset),
-            Show
-        )
-        .unwrap();
         input().disable_mouse_mode().unwrap();
+        cursor().show().unwrap();
     }
 
     fn refresh(&mut self) {


### PR DESCRIPTION
Something is wrong at the moment when finishing up, when the crossterm backend is used.

The terminal is left in a strange state: the previous contents of the terminal (as before the program) are visible, however the cursor is invisible (and reset to the top left), and clicking the mouse spams
escape codes.

For some reason the `execute!` block in `finish` is failing. But it doesn't seem to be necessary: crossterm already restores the alternative screen at shutdown, which also restores the original cursor position and attributes.

Do make sure that mouse mode is stopped and that the cursor is visible.