### PR TITLE
crossterm, termion: Reset bold with SGR 22 instead of 21

### DIFF
--- a/src/backend/crossterm.rs
+++ b/src/backend/crossterm.rs
@@ -252,7 +252,7 @@ impl backend::Backend for Backend {
         match effect {
             theme::Effect::Simple => (),
             theme::Effect::Reverse => self.set_attr(Attribute::NoInverse),
-            theme::Effect::Bold => self.set_attr(Attribute::NoBold),
+            theme::Effect::Bold => self.set_attr(Attribute::NormalIntensity),
             theme::Effect::Italic => self.set_attr(Attribute::NoItalic),
             theme::Effect::Strikethrough => {
                 self.set_attr(Attribute::NotCrossedOut)

--- a/src/backend/termion.rs
+++ b/src/backend/termion.rs
@@ -232,7 +232,7 @@ impl backend::Backend for Backend {
         match effect {
             theme::Effect::Simple => (),
             theme::Effect::Reverse => self.write(tstyle::NoInvert),
-            theme::Effect::Bold => self.write(tstyle::NoBold),
+            theme::Effect::Bold => self.write(tstyle::NoFaint),
             theme::Effect::Italic => self.write(tstyle::NoItalic),
             theme::Effect::Strikethrough => self.write(tstyle::NoCrossedOut),
             theme::Effect::Underline => self.write(tstyle::NoUnderline),


### PR DESCRIPTION
NoBold (21) doesn't work in many terminals to disable bold.
22 (named NormalIntensity in crossterm, and NoFaint in termion) seems to do a better job.

Attempt at fixing #401.