### PR TITLE
Change tertiary color to white instead of grey

### DIFF
--- a/src/theme/palette.rs
+++ b/src/theme/palette.rs
@@ -143,7 +143,7 @@ impl Palette {
 /// * `View` => `Dark(White)`
 /// * `Primary` => `Dark(Black)`
 /// * `Secondary` => `Dark(Blue)`
-/// * `Tertiary` => `Dark(White)`
+/// * `Tertiary` => `Light(White)`
 /// * `TitlePrimary` => `Dark(Red)`
 /// * `TitleSecondary` => `Dark(Yellow)`
 /// * `Highlight` => `Dark(Red)`
@@ -161,7 +161,7 @@ impl Default for Palette {
                 View => Dark(White),
                 Primary => Dark(Black),
                 Secondary => Dark(Blue),
-                Tertiary => Dark(White),
+                Tertiary => Light(White),
                 TitlePrimary => Dark(Red),
                 TitleSecondary => Light(Blue),
                 Highlight => Dark(Red),


### PR DESCRIPTION
Change the tertiary color in the default theme to white instead of light grey.

Currently, the tertiary color is the same as the view background color, making it invisible as foreground color. This makes the Outset effect not work as (I think) intended.

Before:
![a](https://user-images.githubusercontent.com/43048142/69918557-b2190480-1473-11ea-9135-703949a33825.png)

After:
![b](https://user-images.githubusercontent.com/43048142/69918561-bba26c80-1473-11ea-90fa-73d72db28c5f.png)
