### PR TITLE
Fix scroll event conversion in crossterm backend

### DIFF
--- a/src/backend/crossterm.rs
+++ b/src/backend/crossterm.rs
@@ -275,7 +275,7 @@ impl Backend {
                         position = (x, y).into();
                     }
                     CMouseEvent::ScrollUp(x, y, _) => {
-                        event = MouseEvent::WheelDown;
+                        event = MouseEvent::WheelUp;
                         position = (x, y).into();
                     }
                 };


### PR DESCRIPTION
As it stands, `ScrollUp` events are interpreted as `WheelDown`; this pr fixes that.