### PR TITLE
Use mvaddnstr when printing repeated strs

### DIFF
--- a/src/backend/curses/n.rs
+++ b/src/backend/curses/n.rs
@@ -380,12 +380,7 @@ impl backend::Backend for Backend {
 
     fn print_at_rep(&self, pos: Vec2, repetitions: usize, text: &str) {
         if repetitions > 0 {
-            ncurses::mvaddstr(pos.y as i32, pos.x as i32, text);
-            let mut dupes_left = repetitions - 1;
-            while dupes_left > 0 {
-                ncurses::addstr(text);
-                dupes_left -= 1;
-            }
+            ncurses::mvaddnstr(pos.y as i32, pos.x as i32, text, repetitions as i32);
         }
     }
 }

--- a/src/backend/curses/pan.rs
+++ b/src/backend/curses/pan.rs
@@ -428,12 +428,7 @@ impl backend::Backend for Backend {
 
     fn print_at_rep(&self, pos: Vec2, repetitions: usize, text: &str) {
         if repetitions > 0 {
-            self.window.mvaddstr(pos.y as i32, pos.x as i32, text);
-            let mut dupes_left = repetitions - 1;
-            while dupes_left > 0 {
-                self.window.addstr(text);
-                dupes_left -= 1;
-            }
+            self.window.mvaddnstr(pos.y as i32, pos.x as i32, text, repetitions as i32);
         }
     }
 


### PR DESCRIPTION
This change uses `mvaddnstr` rather than `mvaddstr` in n/pancurses' `print_at_rep` implementation. This is a slight optimization as `mvaddstr` will create a `CString` every time it's called, while `mvaddnstr` will only construct a single string and print it N times.