### PR TITLE
[Doc] Improves the documentation about using custom themes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,10 @@
 //! ## Themes
 //!
 //! Cursive supports configuring the feels and looks of your application with
-//! custom themes and colors. For details see [`Cursive::theme`].
+//! custom themes and colors. For details see documentation of the
+//! [`cursive::theme`] module.
+//!
+//! [`cursive::theme`]: ./theme/index.html
 #![deny(missing_docs)]
 
 // We use chan_signal to detect SIGWINCH.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,11 @@
 //! and log to it instead of stdout.
 //!
 //! Or you can use gdb as usual.
+//! 
+//! ## Themes
+//!
+//! Cursive supports configuring the feels and looks of your application with
+//! custom themes and colors. For details see [`Cursive::theme`].
 #![deny(missing_docs)]
 
 // We use chan_signal to detect SIGWINCH.

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -106,11 +106,34 @@
 //!
 //! # Themes
 //!
-//! A theme defines the color palette an application will use, as well as
-//! various options to style views.
+//! A theme is a [`Theme`] object that defines the color palette an 
+//! application will use, as well as various options to style views.
 //!
-//! Themes are described in toml configuration files, so it requires 
-//! the "toml" feature to be enabled.
+//! There are several ways to set a theme for the application:
+//!
+//! * Construct a [`Theme`] object by setting every field individually.
+//! * Get the current theme with [`Cursive::current_theme`] method and
+//!   changing the required fields (for example see [theme_manual example]).
+//! * Using a toml file as a theme configuration (for example see
+//!   [theme example]).
+//!
+//! ## Configuring theme with toml
+//!
+//! This requires `toml` feature to be enabled. 
+//!
+//! ```toml
+//! [dependencies]
+//! cursive = { version = "0.14", features = ["toml"] }
+//! ```
+//!
+//! To use the theme in our application, load it with [`Cursive::load_toml`]
+//! method (or use [`theme::load_theme_file`] to aquire the
+//! theme object).
+//!
+//! ```rust
+//! let siv = Cursive::default();
+//! siv.load_toml(include_str!("<path_to_theme_file>.toml")).unwrap();
+//! ```
 //!
 //! Here are the possible entries (all fields are optional):
 //!
@@ -144,20 +167,19 @@
 //!     highlight          = "#F00"
 //!     highlight_inactive = "#5555FF"
 //! ```
-//!
-//! To use a custom theme in your project, enable the "toml" feature:
-//!
-//! ```toml
-//! [dependencies]
-//! cursive = { version = "0.14", features = ["toml"] }
-//! ```
-//!
-//! Then create a theme file somewhere in your project (example of the
-//! file contents are above). Use your theme from the code:
-//! ```rust
-//! let siv = Cursive::default();
-//! siv.load_toml(include_str!("<path_to_theme_file>.toml")).unwrap();
-//! ```
+//! 
+//! [`Color`]: ./enum.Color.html
+//! [`PaletteColor`]: ./enum.PaletteColor.html
+//! [`Palette`]: ./struct.Palette.html
+//! [`ColorType`]: ./enum.ColorType.html
+//! [`ColorStyle`]: ./struct.ColorStyle.html
+//! [`Effect`]: ./enum.Effect.html
+//! [`Theme`]: ./struct.Theme.html
+//! [`Cursive::current_theme`]: ../struct.Cursive.html#method.current_theme
+//! [theme_manual example]: https://github.com/gyscos/cursive/blob/master/examples/theme_manual.rs
+//! [theme example]: https://github.com/gyscos/cursive/blob/master/examples/theme.rs
+//! [`Cursive::load_toml`]: ../struct.Cursive.html#method.load_toml
+//! [`theme::load_theme_file`]: ./fn.load_theme_file.html
 mod border_style;
 mod color;
 mod color_pair;
@@ -245,7 +267,7 @@ impl From<toml::de::Error> for Error {
 }
 
 #[cfg(feature = "toml")]
-/// Loads a theme from file and sets it as active.
+/// Loads a theme from file.
 ///
 /// Must have the `toml` feature enabled.
 pub fn load_theme_file<P: AsRef<Path>>(filename: P) -> Result<Theme, Error> {

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -109,9 +109,10 @@
 //! A theme defines the color palette an application will use, as well as
 //! various options to style views.
 //!
-//! Themes are described in toml configuration files. All fields are optional.
+//! Themes are described in toml configuration files, so it requires 
+//! the "toml" feature to be enabled.
 //!
-//! Here are the possible entries:
+//! Here are the possible entries (all fields are optional):
 //!
 //! ```toml
 //! # Every field in a theme file is optional.
@@ -142,6 +143,20 @@
 //!     # Lower precision values can use only 3 digits.
 //!     highlight          = "#F00"
 //!     highlight_inactive = "#5555FF"
+//! ```
+//!
+//! To use a custom theme in your project, enable the "toml" feature:
+//!
+//! ```toml
+//! [dependencies]
+//! cursive = { version = "0.14", features = ["toml"] }
+//! ```
+//!
+//! Then create a theme file somewhere in your project (example of the
+//! file contents are above). Use your theme from the code:
+//! ```rust
+//! let siv = Cursive::default();
+//! siv.load_toml(include_str!("<path_to_theme_file>.toml")).unwrap();
 //! ```
 mod border_style;
 mod color;


### PR DESCRIPTION
As starting to use the cursive library I've found it challenging to
figure out how to actually use the themes. Only after checking the
source code, and another library actually using this feature, I've
managed to apply it to my project.

This change makes it easier for new commers to use toml themes by
extending the documentationn