### PR TITLE
Fix for cursive issue #428, "Rendering an empty SelectView..."

### DIFF
--- a/src/views/select_view.rs
+++ b/src/views/select_view.rs
@@ -892,12 +892,15 @@ impl<T: 'static> View for SelectView<T> {
                 printer.print((0, 0), "<");
                 printer.print((x, 0), ">");
 
-                let label = &self.items[self.focus()].label;
+                if let Some(label) =
+                    self.items.get(self.focus()).map(|item| &item.label)
+                {
+                    // And center the text?
+                    let offset =
+                        HAlign::Center.get_offset(label.width(), x + 1);
 
-                // And center the text?
-                let offset = HAlign::Center.get_offset(label.width(), x + 1);
-
-                printer.print_styled((offset, 0), label.into());
+                    printer.print_styled((offset, 0), label.into());
+                }
             });
         } else {
             // Non-popup mode: we always print the entire list.


### PR DESCRIPTION
This change fixes cursive issue #428, caused by indexing into an empty
list.  The issue is corrected by using the .get() method to safely
handle the case where the requested index doesn't exist, and renders
no label in that case.

Fixes https://github.com/gyscos/cursive/issues/428