### PR TITLE
theme: Add PaletteColor::HighlightText

### DIFF
--- a/src/theme/color_style.rs
+++ b/src/theme/color_style.rs
@@ -68,12 +68,12 @@ impl ColorStyle {
 
     /// Alternate text with highlight background.
     pub fn highlight() -> Self {
-        Self::new(PaletteColor::View, PaletteColor::Highlight)
+        Self::new(PaletteColor::HighlightText, PaletteColor::Highlight)
     }
 
     /// Highlight color for inactive views (not in focus).
     pub fn highlight_inactive() -> Self {
-        Self::new(PaletteColor::View, PaletteColor::HighlightInactive)
+        Self::new(PaletteColor::HighlightText, PaletteColor::HighlightInactive)
     }
 
     /// Return the color pair that this style represents.

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -35,6 +35,8 @@
 //!   Defaults to **red**.
 //! * **`HighlightInactive`**: used to highlight selected but inactive items.
 //!   Defaults to **blue**.
+//! * **`HighlightText`**: used to print primary text when highlighted
+//!   Defaults to **white**.
 //!
 //! A [`Palette`] then maps each of these to an actual [`Color`].
 //!
@@ -84,11 +86,11 @@
 //!     * Its *foreground* color is `TitleSecondary`.
 //! * **`ColorStyle::highlight()`**: style used to print selected items.
 //!     * Its *background* color is `Highlight`.
-//!     * Its *foreground* color is `View`.
+//!     * Its *foreground* color is `HighlightText`.
 //! * **`ColorStyle::highlight_inactive()`**: style used to print selected,
 //!   but inactive items.
 //!     * Its *background* color is `HighlightInactive`.
-//!     * Its *foreground* color is `View`.
+//!     * Its *foreground* color is `HighlightText`.
 //!
 //! Using one of these pairs when styling your application helps give it a
 //! coherent look.

--- a/src/theme/palette.rs
+++ b/src/theme/palette.rs
@@ -164,6 +164,7 @@ impl Extend<(PaletteColor, Color)> for Palette {
 /// * `TitleSecondary` => `Dark(Yellow)`
 /// * `Highlight` => `Dark(Red)`
 /// * `HighlightInactive` => `Dark(Blue)`
+/// * `HighlightText` => `Dark(White)`
 impl Default for Palette {
     fn default() -> Palette {
         use self::PaletteColor::*;
@@ -182,6 +183,7 @@ impl Default for Palette {
                 TitleSecondary => Light(Blue),
                 Highlight => Dark(Red),
                 HighlightInactive => Dark(Blue),
+                HighlightText => Dark(White),
             },
             custom: HashMap::default(),
         }
@@ -271,6 +273,8 @@ pub enum PaletteColor {
     Highlight,
     /// Color used for highlighting inactive text.
     HighlightInactive,
+    /// Color used for highlighted text
+    HighlightText,
 }
 
 impl PaletteColor {
@@ -297,6 +301,7 @@ impl FromStr for PaletteColor {
             "TitleSecondary" | "title_secondary" => TitleSecondary,
             "Highlight" | "highlight" => Highlight,
             "HighlightInactive" | "highlight_inactive" => HighlightInactive,
+            "HighlightText" | "highlight_text" => HighlightText,
             _ => return Err(()),
         })
     }


### PR DESCRIPTION
You generally want to stick to default colors because of terminal color
schemes. If you don't, you risk getting suboptimal contrast and
difficult-to-read text. When you _do_ want to peg something to a color,
you need to fully specify the foreground and background to ensure you
have enough contrast for text to be readable.

Our project, below
(https://github.com/facebookincubator/resctl/tree/master/resctl/below),
wants to set a less jarring highlight color than red. In order to
effectively do this, we need a way to specify the highlighted text color
without causing a cascade of pegged colors. In other words, if we were
to manually set PaletteColor::View, we would need to manually set
everything PaletteColor::View is `ColorStyle`'d with, and so forth.

I realize this is an API breaking change. I spent some time considering
alternatives (such as detecting whether or not `HighlightText` is set,
and if not, use `View` as the highlighted text color). The problem with
the other options is that you'd need to:

  1) Document the fallback behavior
  2) Maintain backwards compat code paths

Seeing as cursive is pre-1.0 release, I figure this is the best way
forward.