### PR TITLE
Fix the theme example

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -20,3 +20,6 @@ cursive = { path = "../cursive", default-features=false }
 [features]
 default = ["cursive/default"]
 
+[[bin]]
+name = "theme"
+required-features = ["cursive/toml"]

--- a/examples/src/bin/theme.rs
+++ b/examples/src/bin/theme.rs
@@ -3,35 +3,20 @@ use cursive::views::{Dialog, TextView};
 fn main() {
     let mut siv = cursive::default();
 
-    #[cfg(feature = "toml")]
-    {
-        // You can load a theme from a file at runtime for fast development.
-        siv.load_theme_file("assets/style.toml").unwrap();
+    // You can load a theme from a file at runtime for fast development.
+    siv.load_theme_file("assets/style.toml").unwrap();
 
-        // Or you can directly load it from a string for easy deployment.
-        siv.load_toml(include_str!("../assets/style.toml")).unwrap();
+    // Or you can directly load it from a string for easy deployment.
+    siv.load_toml(include_str!("../../assets/style.toml")).unwrap();
 
-        siv.add_layer(
-            Dialog::around(TextView::new(
-                "This application uses a \
-                 custom theme!",
-            ))
-            .title("Themed dialog")
-            .button("Quit", |s| s.quit()),
-        );
-    }
-
-    #[cfg(not(feature = "toml"))]
-    {
-        siv.add_layer(
-            Dialog::around(TextView::new(
-                "Run this example again with the `toml` feature!\n\n\
-                 cargo run --example theme --features toml",
-            ))
-            .title("Themed dialog - missing `toml` feature")
-            .button("Quit", |s| s.quit()),
-        );
-    }
+    siv.add_layer(
+        Dialog::around(TextView::new(
+            "This application uses a \
+             custom theme!",
+        ))
+        .title("Themed dialog")
+        .button("Quit", |s| s.quit()),
+    );
 
     siv.run();
 }


### PR DESCRIPTION
- Remove the inline feature detection, it doesn't work for features of dependencies. Instead use `required-features` in `Cargo.toml` for the  specific binary.

- The asset moved one level up relatively to `../../assets/style.toml`