### PR TITLE
WIP: Add configurable logger feature

### DIFF
--- a/cursive-core/Cargo.toml
+++ b/cursive-core/Cargo.toml
@@ -58,6 +58,7 @@ atty = "0.2"
 [features]
 markdown = ["pulldown-cmark"]
 unstable_scroll = []
+configurable-logger = []
 
 [lib]
 name = "cursive_core"

--- a/cursive/Cargo.toml
+++ b/cursive/Cargo.toml
@@ -65,6 +65,7 @@ crossterm-backend = ["crossterm"]
 markdown = ["cursive_core/markdown"]
 unstable_scroll = ["cursive_core/unstable_scroll"]
 toml = ["cursive_core/toml"]
+configurable-logger = ["cursive_core/configurable-logger"]
 
 [lib]
 name = "cursive"


### PR DESCRIPTION
Hi,

I am currently playing with cursive and had the problem that I cannot configure the logger, so I had a look at the codebase and found that there is just no configurable logger yet.

So this is my proposal (I am planning to implement more features for the logger, most notably handlebars-based templating if you don't mind).

If you approve, we can discuss how to continue on this idea.
I made it available under a feature flag because more features might pull in quite a lot of dependencies (handlebars for example), so I figured that might be a good way.

Of course, this is WIP and not final.