### PR TITLE
Fix text alignment when wrapped

### DIFF
--- a/cursive-core/src/utils/lines/simple/lines_iterator.rs
+++ b/cursive-core/src/utils/lines/simple/lines_iterator.rs
@@ -67,8 +67,15 @@ impl<'a> Iterator for LinesIterator<'a> {
         let start = row.segments.first()?.start;
         let end = row.segments.last()?.end;
 
-        let width = row.width;
+        let spans::Row {
+            width, is_wrapped, ..
+        } = row;
 
-        Some(Row { start, end, width })
+        Some(Row {
+            start,
+            end,
+            width,
+            is_wrapped,
+        })
     }
 }

--- a/cursive-core/src/utils/lines/simple/row.rs
+++ b/cursive-core/src/utils/lines/simple/row.rs
@@ -10,8 +10,12 @@ pub struct Row {
     pub start: usize,
     /// End of the row (excluded)
     pub end: usize,
+
     /// Width of the row, in cells.
     pub width: usize,
+
+    /// Whether or not this text was wrapped onto the next line
+    pub is_wrapped: bool,
 }
 
 impl Row {

--- a/cursive-core/src/utils/lines/spans/lines_iterator.rs
+++ b/cursive-core/src/utils/lines/spans/lines_iterator.rs
@@ -147,6 +147,11 @@ where
             }
         }
 
+        // We can know text was wrapped if the stop was optional,
+        // and there's more coming.
+        let is_wrapped = !chunks.last().map(|c| c.hard_stop).unwrap_or(true)
+            && self.iter.peek().is_some();
+
         let width = chunks.iter().map(|c| c.width).sum();
 
         assert!(width <= self.width);
@@ -159,6 +164,10 @@ where
 
         // TODO: merge consecutive segments of the same span
 
-        Some(Row { segments, width })
+        Some(Row {
+            segments,
+            width,
+            is_wrapped,
+        })
     }
 }

--- a/cursive-core/src/utils/lines/spans/lines_iterator.rs
+++ b/cursive-core/src/utils/lines/spans/lines_iterator.rs
@@ -147,18 +147,7 @@ where
             }
         }
 
-        // We can know text was wrapped if the stop was optional,
-        // and there's more coming.
-        let text_wrap = !chunks.last().map(|c| c.hard_stop).unwrap_or(true)
-            && self.iter.peek().is_some();
-
-        // If we had to break a line in two, then at least pretent we're
-        // taking the full width.
-        let width = if text_wrap {
-            self.width
-        } else {
-            chunks.iter().map(|c| c.width).sum()
-        };
+        let width = chunks.iter().map(|c| c.width).sum();
 
         assert!(width <= self.width);
 

--- a/cursive-core/src/utils/lines/spans/row.rs
+++ b/cursive-core/src/utils/lines/spans/row.rs
@@ -8,6 +8,8 @@ pub struct Row {
     pub segments: Vec<Segment>,
     /// Total width for this row
     pub width: usize,
+    /// Whether or not this text was wrapped onto the next line
+    pub is_wrapped: bool,
 }
 
 impl Row {

--- a/cursive-core/src/views/text_area.rs
+++ b/cursive-core/src/views/text_area.rs
@@ -287,6 +287,7 @@ impl TextArea {
                 start: self.content.len(),
                 end: self.content.len(),
                 width: 0,
+                is_wrapped: false,
             });
         }
     }
@@ -471,12 +472,15 @@ impl View for TextArea {
         // And y = number of rows
         debug!("{:?}", self.rows);
         let scroll_width = if self.rows.len() > constraint.y { 1 } else { 0 };
-        Vec2::new(
-            scroll_width
-                + 1
-                + self.rows.iter().map(|r| r.width).max().unwrap_or(1),
-            self.rows.len(),
-        )
+
+        let content_width = if self.rows.iter().any(|row| row.is_wrapped) {
+            // If any row has been wrapped, we want to take the full width.
+            constraint.x.saturating_sub(1 + scroll_width)
+        } else {
+            self.rows.iter().map(|r| r.width).max().unwrap_or(1)
+        };
+
+        Vec2::new(scroll_width + 1 + content_width, self.rows.len())
     }
 
     fn draw(&self, printer: &Printer) {

--- a/cursive-core/src/views/text_view.rs
+++ b/cursive-core/src/views/text_view.rs
@@ -357,7 +357,12 @@ impl TextView {
             LinesIterator::new(content.get_cache().as_ref(), size.x).collect();
 
         // Desired width
-        self.width = self.rows.iter().map(|row| row.width).max();
+        self.width = if self.rows.iter().any(|row| row.is_wrapped) {
+            // If any rows are wrapped, then require the full width.
+            Some(size.x)
+        } else {
+            self.rows.iter().map(|row| row.width).max()
+        }
     }
 }
 


### PR DESCRIPTION
This changes the `LinesIterator` to return a `width` that corresponds with the actual total length of the chunks, rather than returning the total available width, when a line is wrapped. This effectively reverts 20cb033b8d3c1edab642d9c068443cdd4d7c38b1 (I am not sure why that commit changed it).

Fixes #426