### PR TITLE
Fix backslash crash

### DIFF
--- a/cursive/src/backends/blt.rs
+++ b/cursive/src/backends/blt.rs
@@ -455,7 +455,7 @@ fn blt_keycode_to_char(kc: KeyCode, shift: bool) -> char {
         KeyCode::RightBracket if shift => '}',
         KeyCode::RightBracket => ']',
         KeyCode::Backslash if shift => '|',
-        KeyCode::Backspace => '\\',
+        KeyCode::Backslash => '\\',
         KeyCode::Semicolon if shift => ':',
         KeyCode::Semicolon => ';',
         KeyCode::Apostrophe if shift => '"',


### PR DESCRIPTION
Pressing backslash would cause cursive to panic.