### PR TITLE
menubar should bubble up events which are not handled

### DIFF
--- a/cursive-core/src/cursive.rs
+++ b/cursive-core/src/cursive.rs
@@ -786,16 +786,25 @@ impl Cursive {
         }
 
         if self.menubar.receive_events() {
-            self.menubar.on_event(event).process(self);
-        } else {
-            let offset = if self.menubar.autohide { 0 } else { 1 };
-
-            let result =
-                View::on_event(&mut self.root, event.relativized((0, offset)));
+            let result = self.menubar.on_event(event.clone());
 
             if let EventResult::Consumed(Some(cb)) = result {
                 cb(self);
+                // If the menubar handles this event, we return
+                // early so the event isn't handled twice. Otherwise
+                // the event should bubble up, even if the menubar is
+                // active, to ensure global callbacks are called.
+                return;
             }
+        }
+
+        let offset = if self.menubar.autohide { 0 } else { 1 };
+
+        let result =
+            View::on_event(&mut self.root, event.relativized((0, offset)));
+
+        if let EventResult::Consumed(Some(cb)) = result {
+            cb(self);
         }
     }
 


### PR DESCRIPTION
Hello, and thanks again for all your work on this crate. 

I found an issue where global callbacks were not being called while the menubar was focused. This PR fixes that by ensuring that events bubble up if they are not handled while the menu bar is focused.

I'm not sure this is the most direct way to accomplish this, since it seems if the menubar is focused we could somehow directly call the global events rather than relying on `View::on_event(&mut self.root, event.relativized((0, offset)))` to do it. But I wasn't sure exactly how to accomplish that. This PR does seem to work as-is.