### PR TITLE
Improved the `select` example.

### DIFF
--- a/examples/src/bin/select.rs
+++ b/examples/src/bin/select.rs
@@ -27,12 +27,12 @@ fn main() {
     // Let's override the `j` and `k` keys for navigation
     let select = OnEventView::new(select)
         .on_pre_event_inner('k', |s, _| {
-            s.select_up(1);
-            Some(EventResult::Consumed(None))
+            let cb = s.select_up(1);
+            Some(EventResult::Consumed(Some(cb)))
         })
         .on_pre_event_inner('j', |s, _| {
-            s.select_down(1);
-            Some(EventResult::Consumed(None))
+            let cb = s.select_down(1);
+            Some(EventResult::Consumed(Some(cb)))
         });
 
     let mut siv = cursive::default();


### PR DESCRIPTION
## Introduction
This PR is an effect of my initial confusion with the intended way of handling `Callback`s, and aims to help prevent that from happening to others in future.

## Story time!
I wanted to add custom keybindings to a `SelectView`, so I looked through the examples and found the `select` example which looked like exactly what I needed. After replicating the `OnEventView` wrapper part of the code, the keybindings worked as far as navigating the `SelectView` went, but I noticed all the callbacks set with `SelectView.on_select()` were ignored with the custom keybindings but worked with the default arrow ones.  
I started reading into the documentation, and noticed the `SelectView.select_up()` method returned a `Callback`, and the documentation said it should be ran on the `Cursive`. I couldn't figure out how to get a reference to `Cursive` inside the closure in `OnEventView.on_event_inner()` to run it like the documentation example has shown (something along the lines of `callback(&mut siv)` ), so I tried using `OnEventView.on_event()`, then getting a referece to the `SelectView` by name, and using `Cursive.cb_sink()` to send the `Callback`s but apparently they weren't `Sync` so that didn't work out.

Not until having found #433 and [this comment in particular](https://github.com/gyscos/cursive/issues/433#issuecomment-606799956) did I realize that I should look at the documentation of `EventResult`, which, in turn, made me realize that I can just pass the `Callback` inside the `EventResult`.

## Summary
I thought it would be a good idea to create this small PR to hopefully help other Cursive beginners be less confused :)
It effectively doesn't change anything in this example as far as functionality goes, but it helps bring attention to this important way of handling `Callback`s.