### PR TITLE
new example: autocomplete search box

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -17,6 +17,7 @@ pretty-bytes = "0.2.2"
 rand = "0.7.3"
 cursive = { path = "../cursive", default-features=false }
 crossbeam-channel = "0.4.2"
+lazy_static = "1.4"
 
 [features]
 default = ["cursive/default"]

--- a/examples/src/bin/autocomplete.rs
+++ b/examples/src/bin/autocomplete.rs
@@ -37,10 +37,9 @@ fn main() {
                         // Center the text horizontally
                         .h_align(HAlign::Center)
                         .with_name("matches")
-                        .scrollable()
-                        .fixed_size((20, 10)),
+                        .scrollable(),
                 )
-                .fixed_width(25),
+                .fixed_height(10),
         )
         .button("Quit", Cursive::quit)
         .title("Where are you from?"),

--- a/examples/src/bin/autocomplete.rs
+++ b/examples/src/bin/autocomplete.rs
@@ -37,7 +37,9 @@ fn main() {
                         .on_submit(show_next_window)
                         // Center the text horizontally
                         .h_align(HAlign::Center)
-                        .with_name("matches"),
+                        .with_name("matches")
+                        .scrollable()
+                        .fixed_size((20, 10)),
                 )
                 .fixed_width(25),
         )
@@ -57,7 +59,7 @@ fn on_edit(siv: &mut Cursive, _content: &str, _cursor: usize) {
         let query = query.to_owned().to_lowercase();
         city.contains(&query)
     });
-    // Update the results with the filtered array of cities
+    // Update the `matches` view with the filtered array of cities
     siv.call_on_name("matches", |v: &mut SelectView| {
         v.clear();
         v.add_all_str(matches);

--- a/examples/src/bin/autocomplete.rs
+++ b/examples/src/bin/autocomplete.rs
@@ -22,7 +22,12 @@ fn main() {
         Dialog::around(
             LinearLayout::vertical()
                 // the input is on the top
-                .child(EditView::new().on_edit(on_edit).with_name("query"))
+                .child(
+                    EditView::new()
+                        .on_edit(on_edit)
+                        .on_submit(on_submit)
+                        .with_name("query"),
+                )
                 // search results below the input
                 .child(
                     SelectView::new()
@@ -46,14 +51,23 @@ fn main() {
 fn on_edit(siv: &mut Cursive, _content: &str, _cursor: usize) {
     // Get the query
     let query = siv.find_name::<EditView>("query").unwrap().get_content();
-    // Filter cities with names that starts with the query string
-    let matches = CITIES
-        .lines()
-        .filter(|&city| query.chars().zip(city.chars()).all(|(c, d)| c == d));
+    // Filter cities with names containing query string
+    let matches = CITIES.lines().filter(|&city| {
+        let city = city.to_owned().to_lowercase();
+        let query = query.to_owned().to_lowercase();
+        city.contains(&query)
+    });
     // Update the results with the filtered array of cities
     siv.call_on_name("matches", |v: &mut SelectView| {
         v.clear();
         v.add_all_str(matches);
+    });
+}
+
+fn on_submit(siv: &mut Cursive, _content: &str) {
+    siv.call_on_name("matches", |v: &mut SelectView| {
+        // wont' work; private associated function
+        // v.submit();
     });
 }
 

--- a/examples/src/bin/autocomplete.rs
+++ b/examples/src/bin/autocomplete.rs
@@ -1,10 +1,7 @@
 use cursive::align::HAlign;
-use cursive::event::EventResult;
-use cursive::traits::*;
+use cursive::traits::Scrollable;
 use cursive::view::{Boxable, Identifiable};
-use cursive::views::{
-    Dialog, EditView, LinearLayout, OnEventView, SelectView, TextView,
-};
+use cursive::views::{Dialog, EditView, LinearLayout, SelectView, TextView};
 use cursive::Cursive;
 use lazy_static::lazy_static;
 

--- a/examples/src/bin/autocomplete.rs
+++ b/examples/src/bin/autocomplete.rs
@@ -1,0 +1,66 @@
+use cursive::align::HAlign;
+use cursive::event::EventResult;
+use cursive::traits::*;
+use cursive::view::{Boxable, Identifiable};
+use cursive::views::{
+    Dialog, EditView, LinearLayout, OnEventView, SelectView, TextView,
+};
+use cursive::Cursive;
+use lazy_static::lazy_static;
+
+// This example shows a way to implement a (Google-like) autocomplete search box.
+// Try entering "Tok"!
+
+lazy_static! {
+    static ref CITIES: &'static str = include_str!("../../assets/cities.txt");
+}
+
+fn main() {
+    let mut siv = cursive::default();
+
+    siv.add_layer(
+        Dialog::around(
+            LinearLayout::vertical()
+                // the input is on the top
+                .child(EditView::new().on_edit(on_edit).with_name("query"))
+                // search results below the input
+                .child(
+                    SelectView::new()
+                        // shows all cities by default
+                        .with_all_str(CITIES.lines())
+                        // Sets the callback for when "Enter" is pressed.
+                        .on_submit(show_next_window)
+                        // Center the text horizontally
+                        .h_align(HAlign::Center)
+                        .with_name("matches"),
+                )
+                .fixed_width(25),
+        )
+        .button("Quit", Cursive::quit),
+    );
+
+    siv.run();
+}
+
+// Update results according to the query
+fn on_edit(siv: &mut Cursive, _content: &str, _cursor: usize) {
+    // Get the query
+    let query = siv.find_name::<EditView>("query").unwrap().get_content();
+    // Filter cities with names that starts with the query string
+    let matches = CITIES
+        .lines()
+        .filter(|&city| query.chars().zip(city.chars()).all(|(c, d)| c == d));
+    // Update the results with the filtered array of cities
+    siv.call_on_name("matches", |v: &mut SelectView| {
+        v.clear();
+        v.add_all_str(matches);
+    });
+}
+
+fn show_next_window(siv: &mut Cursive, city: &str) {
+    siv.pop_layer();
+    let text = format!("{} is a great city!", city);
+    siv.add_layer(
+        Dialog::around(TextView::new(text)).button("Quit", |s| s.quit()),
+    );
+}

--- a/examples/src/bin/autocomplete.rs
+++ b/examples/src/bin/autocomplete.rs
@@ -51,17 +51,27 @@ fn main() {
 
 // Update results according to the query
 fn on_edit(siv: &mut Cursive, query: &str, _cursor: usize) {
-    // Filter cities with names containing query string
-    let matches = CITIES.lines().filter(|&city| {
-        let city = city.to_owned().to_lowercase();
-        let query = query.to_owned().to_lowercase();
-        city.contains(&query)
-    });
+    let matches = search_fn(CITIES.lines(), query);
     // Update the `matches` view with the filtered array of cities
     siv.call_on_name("matches", |v: &mut SelectView| {
         v.clear();
         v.add_all_str(matches);
     });
+}
+
+// Filter cities with names containing query string. You can implement your own logic here!
+fn search_fn<'a, 'b, T: std::iter::IntoIterator<Item = &'a str>>(
+    items: T,
+    query: &'b str,
+) -> Vec<&'a str> {
+    items
+        .into_iter()
+        .filter(|&item| {
+            let item = item.to_owned().to_lowercase();
+            let query = query.to_owned().to_lowercase();
+            item.contains(&query)
+        })
+        .collect()
 }
 
 fn on_submit(siv: &mut Cursive, query: &str) {

--- a/examples/src/bin/autocomplete.rs
+++ b/examples/src/bin/autocomplete.rs
@@ -67,8 +67,8 @@ fn search_fn<'a, 'b, T: std::iter::IntoIterator<Item = &'a str>>(
     items
         .into_iter()
         .filter(|&item| {
-            let item = item.to_owned().to_lowercase();
-            let query = query.to_owned().to_lowercase();
+            let item = item.to_lowercase();
+            let query = query.to_lowercase();
             item.contains(&query)
         })
         .collect()


### PR DESCRIPTION
Thank you so much for making this crate that saved my life!

I'm making an app in which Google-like autocomplete search boxes are used often. While entering the query on the top of such a search box, filtered results should be generated below on the fly. 

It seems that there isn't a ready-to-use `View` for this, so I made one by assembling existing `Views`. I guess it might be helpful to add this to `examples`. 