### PR TITLE
Remove outdated comment from button.rs

### DIFF
--- a/cursive-core/src/views/button.rs
+++ b/cursive-core/src/views/button.rs
@@ -169,7 +169,6 @@ impl View for Button {
         let width = self.label.width();
         let self_offset = HAlign::Center.get_offset(width, self.last_size.x);
         match event {
-            // 10 is the ascii code for '\n', that is the return key
             Event::Key(Key::Enter) => {
                 EventResult::Consumed(Some(self.callback.clone()))
             }


### PR DESCRIPTION
Before commit f9c9e565189a32a30ff2b2d1fad594e07e78961b, this match
interpreted the key code 10 as the Enter key.  Since it now uses the
Key::Enter variant instead, the comment explaining the magic number is
no longer needed.