### PR TITLE
Implement Default for XY

### DIFF
--- a/cursive-core/src/xy.rs
+++ b/cursive-core/src/xy.rs
@@ -2,7 +2,7 @@ use crate::direction::Orientation;
 use std::iter;
 
 /// A generic structure with a value for each axis.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct XY<T> {
     /// X-axis value
     pub x: T,


### PR DESCRIPTION
This patch implements Default for XY<T> if T implements Default.  This
makes it easier to deal with types like XY<usize>.