### PR TITLE
Mark XY::stack_{horizontal, vertical} as must_use

### DIFF
--- a/cursive-core/src/vec.rs
+++ b/cursive-core/src/vec.rs
@@ -258,6 +258,7 @@ impl<T: Ord> XY<T> {
 
 impl<T: Ord + Add<Output = T> + Clone> XY<T> {
     /// Returns (max(self.x,other.x), self.y+other.y)
+    #[must_use]
     pub fn stack_vertical(&self, other: &Self) -> Self {
         Self::new(
             max(self.x.clone(), other.x.clone()),
@@ -266,6 +267,7 @@ impl<T: Ord + Add<Output = T> + Clone> XY<T> {
     }
 
     /// Returns (self.x+other.x, max(self.y,other.y))
+    #[must_use]
     pub fn stack_horizontal(&self, other: &Self) -> Self {
         Self::new(
             self.x.clone() + other.x.clone(),


### PR DESCRIPTION
The method names `stack_horizontal` and `stack_vertical` don’t make it clear whether the methods modify self or return the modified version.  Therefore, it is easy to use them wrong if you don’t look at the documentation.  This patch adds the `must_use` attribute to both methods to make it easier to spot such mistakes.