### PR TITLE
Add cursive-markup to readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -76,6 +76,7 @@ Here are a few crates implementing new views for you to use:
 * [cursive-aligned-view](https://github.com/deinstapel/cursive-aligned-view): A view wrapper for gyscos/cursive views which aligns child views.
 * [cursive-async-view](https://github.com/deinstapel/cursive-async-view): A loading-screen wrapper.
 * [cursive-flexi-logger-view](https://github.com/deinstapel/cursive-flexi-logger-view): An alternative debug view using `emabee/flexi_logger`.
+* [cursive-markup](https://sr.ht/~ireas/cursive-markup-rs): A view that renderes HTML or other markup.
 * [cursive-multiplex](https://github.com/deinstapel/cursive-multiplex): A tmux like multiplexer.
 * [cursive-tabs](https://github.com/deinstapel/cursive-tabs): Tabs.
 * [cursive_calendar_view](https://github.com/BonsaiDen/cursive_calendar_view): A basic calendar view implementation.

--- a/Readme.md
+++ b/Readme.md
@@ -76,7 +76,7 @@ Here are a few crates implementing new views for you to use:
 * [cursive-aligned-view](https://github.com/deinstapel/cursive-aligned-view): A view wrapper for gyscos/cursive views which aligns child views.
 * [cursive-async-view](https://github.com/deinstapel/cursive-async-view): A loading-screen wrapper.
 * [cursive-flexi-logger-view](https://github.com/deinstapel/cursive-flexi-logger-view): An alternative debug view using `emabee/flexi_logger`.
-* [cursive-markup](https://sr.ht/~ireas/cursive-markup-rs): A view that renderes HTML or other markup.
+* [cursive-markup](https://sr.ht/~ireas/cursive-markup-rs): A view that renders HTML or other markup.
 * [cursive-multiplex](https://github.com/deinstapel/cursive-multiplex): A tmux like multiplexer.
 * [cursive-tabs](https://github.com/deinstapel/cursive-tabs): Tabs.
 * [cursive_calendar_view](https://github.com/BonsaiDen/cursive_calendar_view): A basic calendar view implementation.


### PR DESCRIPTION
The [cursive-markup](https://sr.ht/~ireas/cursive-markup-rs) crate provides a view that can render HTML or other markup.  This patch adds it to the list of third-party views in the readme.