### PR TITLE
Add Color::None to be able to create styles with only foreground or background color

### DIFF
--- a/cursive-core/src/theme/color.rs
+++ b/cursive-core/src/theme/color.rs
@@ -97,7 +97,9 @@ pub enum Color {
     /// These 216 possible colors are part of the default color palette (256 colors).
     RgbLowRes(u8, u8, u8),
 
-    /// Unset
+    /// No color
+    ///
+    /// The color will be determined by the active color of the view.
     None,
 }
 

--- a/cursive-core/src/theme/color.rs
+++ b/cursive-core/src/theme/color.rs
@@ -97,10 +97,10 @@ pub enum Color {
     /// These 216 possible colors are part of the default color palette (256 colors).
     RgbLowRes(u8, u8, u8),
 
-    /// No color
+    /// Inherit the color of the parent 
     ///
-    /// The color will be determined by the active color of the view.
-    None,
+    /// The color will be set by the parent.
+    InheritParent,
 }
 
 impl Color {

--- a/cursive-core/src/theme/color.rs
+++ b/cursive-core/src/theme/color.rs
@@ -96,6 +96,9 @@ pub enum Color {
     ///
     /// These 216 possible colors are part of the default color palette (256 colors).
     RgbLowRes(u8, u8, u8),
+
+    /// Unset
+    None,
 }
 
 impl Color {

--- a/cursive/src/backends/blt.rs
+++ b/cursive/src/backends/blt.rs
@@ -343,7 +343,7 @@ fn colour_to_blt_colour(
     curr_clr: Color,
 ) -> BltColor {
     let clr = match clr {
-        Color::None => curr_clr,
+        Color::InheritParent => curr_clr,
         _ => clr,
     };
     let (r, g, b) = match clr {
@@ -382,7 +382,7 @@ fn colour_to_blt_colour(
             (f32::from(g) / 5.0 * 255.0) as u8,
             (f32::from(b) / 5.0 * 255.0) as u8,
         ),
-        Color::None => (0, 0, 0),
+        Color::InheritParent => (0, 0, 0),
     };
     BltColor::from_rgb(r, g, b)
 }

--- a/cursive/src/backends/blt.rs
+++ b/cursive/src/backends/blt.rs
@@ -253,8 +253,16 @@ impl backend::Backend for Backend {
             back: blt_colour_to_colour(state::background()),
         };
 
-        let fg = colour_to_blt_colour(color.front, ColorRole::Foreground);
-        let bg = colour_to_blt_colour(color.back, ColorRole::Background);
+        let fg = colour_to_blt_colour(
+            color.front,
+            ColorRole::Foreground,
+            current.front,
+        );
+        let bg = colour_to_blt_colour(
+            color.back,
+            ColorRole::Background,
+            current.back,
+        );
 
         terminal::set_colors(fg, bg);
 
@@ -307,6 +315,7 @@ impl backend::Backend for Backend {
         terminal::set_background(colour_to_blt_colour(
             color,
             ColorRole::Background,
+            Color::Dark(BaseColor::Black),
         ));
         terminal::clear(None);
     }
@@ -328,7 +337,15 @@ fn blt_colour_to_colour(c: BltColor) -> Color {
     Color::Rgb(c.red, c.green, c.blue)
 }
 
-fn colour_to_blt_colour(clr: Color, role: ColorRole) -> BltColor {
+fn colour_to_blt_colour(
+    clr: Color,
+    role: ColorRole,
+    curr_clr: Color,
+) -> BltColor {
+    let clr = match clr {
+        Color::None => curr_clr,
+        _ => clr,
+    };
     let (r, g, b) = match clr {
         Color::TerminalDefault => {
             let clr = match role {
@@ -365,6 +382,7 @@ fn colour_to_blt_colour(clr: Color, role: ColorRole) -> BltColor {
             (f32::from(g) / 5.0 * 255.0) as u8,
             (f32::from(b) / 5.0 * 255.0) as u8,
         ),
+        Color::None => (0, 0, 0),
     };
     BltColor::from_rgb(r, g, b)
 }

--- a/cursive/src/backends/crossterm.rs
+++ b/cursive/src/backends/crossterm.rs
@@ -185,7 +185,7 @@ fn translate_color(
             Color::AnsiValue(16 + 36 * r + 6 * g + b)
         }
         theme::Color::TerminalDefault => Color::Reset,
-        theme::Color::None => {
+        theme::Color::InheritParent => {
             translate_color(curr_color, theme::Color::TerminalDefault)
         }
     }
@@ -362,10 +362,10 @@ impl backend::Backend for Backend {
     fn set_color(&self, mut color: theme::ColorPair) -> theme::ColorPair {
         let current_style = self.current_style.get();
 
-        if color.back == theme::Color::None {
+        if color.back == theme::Color::InheritParent {
             color.back = current_style.back;
         }
-        if color.front == theme::Color::None {
+        if color.front == theme::Color::InheritParent {
             color.front = current_style.front;
         }
 

--- a/cursive/src/backends/curses/mod.rs
+++ b/cursive/src/backends/curses/mod.rs
@@ -78,6 +78,7 @@ fn find_closest_pair(pair: ColorPair, max_colors: i16) -> (i16, i16) {
 /// downgraded to the closest one available.
 fn find_closest(color: Color, max_colors: i16) -> i16 {
     match color {
+        Color::None => -1,
         Color::TerminalDefault => -1,
         Color::Dark(BaseColor::Black) => 0,
         Color::Dark(BaseColor::Red) => 1,

--- a/cursive/src/backends/curses/mod.rs
+++ b/cursive/src/backends/curses/mod.rs
@@ -78,7 +78,7 @@ fn find_closest_pair(pair: ColorPair, max_colors: i16) -> (i16, i16) {
 /// downgraded to the closest one available.
 fn find_closest(color: Color, max_colors: i16) -> i16 {
     match color {
-        Color::None => -1,
+        Color::InheritParent => -1,
         Color::TerminalDefault => -1,
         Color::Dark(BaseColor::Black) => 0,
         Color::Dark(BaseColor::Red) => 1,

--- a/cursive/src/backends/curses/n.rs
+++ b/cursive/src/backends/curses/n.rs
@@ -173,8 +173,15 @@ impl Backend {
     }
 
     /// Checks the pair in the cache, or re-define a color if needed.
-    fn get_or_create(&self, pair: ColorPair) -> i16 {
+    fn get_or_create(&self, mut pair: ColorPair) -> i16 {
         let mut pairs = self.pairs.borrow_mut();
+        let current_style = self.current_style.get();
+        if pair.back == Color::None {
+            pair.back = current_style.back;
+        }
+        if pair.front == Color::None {
+            pair.front = current_style.front;
+        }
 
         // Find if we have this color in stock
         let result = find_closest_pair(pair);

--- a/cursive/src/backends/curses/n.rs
+++ b/cursive/src/backends/curses/n.rs
@@ -176,10 +176,10 @@ impl Backend {
     fn get_or_create(&self, mut pair: ColorPair) -> i16 {
         let mut pairs = self.pairs.borrow_mut();
         let current_style = self.current_style.get();
-        if pair.back == Color::None {
+        if pair.back == Color::InheritParent {
             pair.back = current_style.back;
         }
-        if pair.front == Color::None {
+        if pair.front == Color::InheritParent {
             pair.front = current_style.front;
         }
 

--- a/cursive/src/backends/termion.rs
+++ b/cursive/src/backends/termion.rs
@@ -232,10 +232,10 @@ impl backend::Backend for Backend {
     fn set_color(&self, mut color: theme::ColorPair) -> theme::ColorPair {
         let current_style = self.current_style.get();
 
-        if color.front == theme::Color::None {
+        if color.front == theme::Color::InheritParent {
             color.front = current_style.front;
         }
-        if color.back == theme::Color::None {
+        if color.back == theme::Color::InheritParent {
             color.back = current_style.back;
         }
 
@@ -338,7 +338,7 @@ where
     F: FnOnce(&dyn tcolor::Color) -> R,
 {
     match clr {
-        theme::Color::None => f(&tcolor::Reset),
+        theme::Color::InheritParent => f(&tcolor::Reset),
         theme::Color::TerminalDefault => f(&tcolor::Reset),
         theme::Color::Dark(theme::BaseColor::Black) => f(&tcolor::Black),
         theme::Color::Dark(theme::BaseColor::Red) => f(&tcolor::Red),

--- a/cursive/src/backends/termion.rs
+++ b/cursive/src/backends/termion.rs
@@ -229,8 +229,15 @@ impl backend::Backend for Backend {
         "termion"
     }
 
-    fn set_color(&self, color: theme::ColorPair) -> theme::ColorPair {
+    fn set_color(&self, mut color: theme::ColorPair) -> theme::ColorPair {
         let current_style = self.current_style.get();
+
+        if color.front == theme::Color::None {
+            color.front = current_style.front;
+        }
+        if color.back == theme::Color::None {
+            color.back = current_style.back;
+        }
 
         if current_style != color {
             self.apply_colors(color);
@@ -331,6 +338,7 @@ where
     F: FnOnce(&dyn tcolor::Color) -> R,
 {
     match clr {
+        theme::Color::None => f(&tcolor::Reset),
         theme::Color::TerminalDefault => f(&tcolor::Reset),
         theme::Color::Dark(theme::BaseColor::Black) => f(&tcolor::Black),
         theme::Color::Dark(theme::BaseColor::Red) => f(&tcolor::Red),


### PR DESCRIPTION
Hello,

I'm using Cursive in a personal project and stumbled upon a problem with the styled `SpannedString`. I'm using a `SelectView` to list piped content or the content of a file. For example, I piped the colored output of `pygmentize` into my application. To colorize the input, I'm parsing the color sequences and transform them to styled `SpannedString`s. Because in some cases the sequences specify only one color (e.g. only foreground color) but `cursive::theme::ColorStyle` requires both, I always set the missing color to `Color::TerminalDefault`. That's fine, but now the highlighting of the selection breaks.

A minimal example of the problem and the proposed solution:
```rust
use cursive::theme::*;
use cursive::utils::span::*;
use cursive::view::*;
use cursive::views::*;
use cursive::*;

fn main() {
    let mut siv = Cursive::default();
    siv.set_global_callback('q', |s| s.quit());
    siv.add_fullscreen_layer(
        SelectView::<String>::new()
            .with_name("select-view")
            .full_width()
            .full_height(),
    );

    let mut theme = siv.current_theme().clone();
    theme.palette.set_color("view", Color::TerminalDefault);
    theme.palette.set_color("primary", Color::Dark(BaseColor::White));
    theme.palette.set_color("highlight", Color::from_256colors(238));
    siv.set_theme(theme);

    let style_no_bg = Style {
        color: Some(ColorStyle::new(
            ColorType::Color(Color::Dark(BaseColor::Yellow)),
            ColorType::Color(Color::None),
        )),
        ..Default::default()
    };
    let style_default = Style {
        color: Some(ColorStyle::new(
            ColorType::Color(Color::Dark(BaseColor::Yellow)),
            ColorType::Color(Color::TerminalDefault),
        )),
        ..Default::default()
    };

    if let Some(mut v) = siv.find_name::<SelectView<String>>("select-view") {
        v.add_item_str("Plain text without any style");
        v.add_item(
            SpannedString::styled("Text with only fg color set", style_no_bg),
            "".into(),
        );
        v.add_item(
            SpannedString::styled("Text with bg color because you have to set one", style_default),
            "".into(),
        );
    }

    siv.run();
}
```

[![asciicast](https://asciinema.org/a/377566.svg)](https://asciinema.org/a/377566)

As you can see, because I have to set a background color for the style, the background color set by the highlighting of the `SelectView` is overridden. To circumvent this, I added the `None` option. If this option is set for any color, the currently active color will be used instead. I also added support in all available backends.

I really hope I didn't miss anything. Many thanks in advance.