### PR TITLE
Add getters & other utility methods to Dialog

### DIFF
--- a/cursive-core/src/views/dialog.rs
+++ b/cursive-core/src/views/dialog.rs
@@ -11,7 +11,6 @@ use crate::{
 };
 use std::cell::Cell;
 use std::cmp::{max, min};
-use std::mem::replace;
 use unicode_width::UnicodeWidthStr;
 
 /// Identifies currently focused element in [`Dialog`].
@@ -167,9 +166,12 @@ impl Dialog {
     /// Previous content will be returned.
     pub fn set_content<V: IntoBoxedView>(&mut self, view: V) -> Box<dyn View> {
         self.invalidate();
-        replace(&mut self.content, LastSizeView::new(BoxedView::boxed(view)))
-            .view
-            .unwrap()
+        std::mem::replace(
+            &mut self.content,
+            LastSizeView::new(BoxedView::boxed(view)),
+        )
+        .view
+        .unwrap()
     }
 
     /// Convenient method to create a dialog with a simple text content.

--- a/cursive-core/src/views/dialog.rs
+++ b/cursive-core/src/views/dialog.rs
@@ -307,6 +307,11 @@ impl Dialog {
         self.invalidate();
     }
 
+    /// Get the title of the dialog.
+    pub fn get_title(&self) -> &str {
+        &self.title
+    }
+
     /// Sets the horizontal position of the title in the dialog.
     /// The default position is `HAlign::Center`
     pub fn title_position(self, align: HAlign) -> Self {

--- a/cursive-core/src/views/dialog.rs
+++ b/cursive-core/src/views/dialog.rs
@@ -357,18 +357,6 @@ impl Dialog {
         self.padding(Margins::lrtb(left, right, top, bottom))
     }
 
-    /// Gets the padding in the dialog.
-    ///
-    /// Returns Left, Right, Tob, Bottom fields as a tuple.
-    pub fn get_padding_lrtb(&self) -> (usize, usize, usize, usize) {
-        (
-            self.padding.left,
-            self.padding.right,
-            self.padding.top,
-            self.padding.bottom,
-        )
-    }
-
     /// Sets the padding in the dialog (around content and buttons).
     ///
     /// Chainable variant.
@@ -386,11 +374,6 @@ impl Dialog {
         self.padding.top = padding;
     }
 
-    /// Gets the top padding in the dialog (under the title).
-    pub fn get_padding_top(&mut self) -> usize {
-        self.padding.top
-    }
-
     /// Sets the bottom padding in the dialog (under buttons).
     pub fn padding_bottom(self, padding: usize) -> Self {
         self.with(|s| s.set_padding_bottom(padding))
@@ -399,11 +382,6 @@ impl Dialog {
     /// Sets the bottom padding in the dialog (under buttons).
     pub fn set_padding_bottom(&mut self, padding: usize) {
         self.padding.bottom = padding;
-    }
-
-    /// Gets the bottom padding in the dialog (under buttons).
-    pub fn get_padding_bottom(&mut self) -> usize {
-        self.padding.bottom
     }
 
     /// Sets the left padding in the dialog.
@@ -416,11 +394,6 @@ impl Dialog {
         self.padding.left = padding;
     }
 
-    /// Gets the left padding in the dialog.
-    pub fn get_padding_left(&mut self) -> usize {
-        self.padding.left
-    }
-
     /// Sets the right padding in the dialog.
     pub fn padding_right(self, padding: usize) -> Self {
         self.with(|s| s.set_padding_right(padding))
@@ -429,11 +402,6 @@ impl Dialog {
     /// Sets the right padding in the dialog.
     pub fn set_padding_right(&mut self, padding: usize) {
         self.padding.right = padding;
-    }
-
-    /// Gets the left padding in the dialog.
-    pub fn get_padding_right(&mut self) -> usize {
-        self.padding.right
     }
 
     /// Iterate the buttons of this dialog.

--- a/cursive-core/src/views/dialog.rs
+++ b/cursive-core/src/views/dialog.rs
@@ -258,6 +258,11 @@ impl Dialog {
         self
     }
 
+    /// Gets the horizontal alignment for the buttons.
+    pub fn get_h_align(&self) -> HAlign {
+        self.align.h
+    }
+
     /*
      * Commented out because currently un-implemented.
      *

--- a/cursive-core/src/views/dialog.rs
+++ b/cursive-core/src/views/dialog.rs
@@ -11,6 +11,7 @@ use crate::{
 };
 use std::cell::Cell;
 use std::cmp::max;
+use std::mem::replace;
 use unicode_width::UnicodeWidthStr;
 
 /// Identifies currently focused element in [`Dialog`].
@@ -165,6 +166,19 @@ impl Dialog {
     pub fn set_content<V: IntoBoxedView>(&mut self, view: V) {
         self.content = LastSizeView::new(BoxedView::boxed(view));
         self.invalidate();
+    }
+
+    /// Replace the content for this dialog.
+    ///
+    /// Previous content will be returned as a `BoxedView`.
+    pub fn replace_content<V: IntoBoxedView>(&mut self, view: V) -> BoxedView {
+        let old_content = replace(
+            &mut self.content,
+            LastSizeView::new(BoxedView::boxed(view)),
+        );
+        self.invalidate();
+
+        old_content.view
     }
 
     /// Convenient method to create a dialog with a simple text content.

--- a/cursive-core/src/views/dialog.rs
+++ b/cursive-core/src/views/dialog.rs
@@ -118,7 +118,9 @@ impl Dialog {
     ///     .button("Quit", |s| s.quit());
     /// ```
     pub fn content<V: IntoBoxedView>(self, view: V) -> Self {
-        self.with(|s| s.set_content(view))
+        self.with(|s| {
+            s.set_content(view);
+        })
     }
 
     /// Gets the content of this dialog.
@@ -162,23 +164,12 @@ impl Dialog {
 
     /// Sets the content for this dialog.
     ///
-    /// Previous content will be dropped.
-    pub fn set_content<V: IntoBoxedView>(&mut self, view: V) {
-        self.content = LastSizeView::new(BoxedView::boxed(view));
+    /// Previous content will be returned.
+    pub fn set_content<V: IntoBoxedView>(&mut self, view: V) -> Box<dyn View> {
         self.invalidate();
-    }
-
-    /// Replace the content for this dialog.
-    ///
-    /// Previous content will be returned as a `BoxedView`.
-    pub fn replace_content<V: IntoBoxedView>(&mut self, view: V) -> BoxedView {
-        let old_content = replace(
-            &mut self.content,
-            LastSizeView::new(BoxedView::boxed(view)),
-        );
-        self.invalidate();
-
-        old_content.view
+        replace(&mut self.content, LastSizeView::new(BoxedView::boxed(view)))
+            .view
+            .unwrap()
     }
 
     /// Convenient method to create a dialog with a simple text content.

--- a/cursive-core/src/views/dialog.rs
+++ b/cursive-core/src/views/dialog.rs
@@ -445,10 +445,19 @@ impl Dialog {
         self.buttons.iter().map(|b| &b.button.view)
     }
 
-    /// Returns an iterator on this buttons for this dialog.
-    pub fn buttons_mut(&mut self) -> impl Iterator<Item = &mut Button> {
+    /// Mutably iterate the buttons of this dialog.
+    pub fn iter_buttons_mut(&mut self) -> impl Iterator<Item = &mut Button> {
         self.invalidate();
         self.buttons.iter_mut().map(|b| &mut b.button.view)
+    }
+
+    /// Mutably iterate the buttons of this dialog.
+    #[deprecated(
+        since = "0.2.2",
+        note = "Please use iter_buttons_mut instead"
+    )]
+    pub fn buttons_mut(&mut self) -> impl Iterator<Item = &mut Button> {
+        self.iter_buttons_mut()
     }
 
     /// Returns currently focused element

--- a/cursive-core/src/views/dialog.rs
+++ b/cursive-core/src/views/dialog.rs
@@ -440,6 +440,11 @@ impl Dialog {
         self.padding.right
     }
 
+    /// Iterate the buttons of this dialog.
+    pub fn iter_buttons(&self) -> impl Iterator<Item = &Button> {
+        self.buttons.iter().map(|b| &b.button.view)
+    }
+
     /// Returns an iterator on this buttons for this dialog.
     pub fn buttons_mut(&mut self) -> impl Iterator<Item = &mut Button> {
         self.invalidate();

--- a/cursive-core/src/views/dialog.rs
+++ b/cursive-core/src/views/dialog.rs
@@ -10,7 +10,7 @@ use crate::{
     Cursive, Printer, Vec2, With,
 };
 use std::cell::Cell;
-use std::cmp::max;
+use std::cmp::{max, min};
 use std::mem::replace;
 use unicode_width::UnicodeWidthStr;
 
@@ -478,7 +478,7 @@ impl Dialog {
                 DialogFocus::Content
             }
             DialogFocus::Button(c) => {
-                DialogFocus::Button(max(c, self.buttons.len()))
+                DialogFocus::Button(min(c, self.buttons.len()))
             }
         }
     }

--- a/cursive-core/src/views/dialog.rs
+++ b/cursive-core/src/views/dialog.rs
@@ -324,6 +324,11 @@ impl Dialog {
         self.title_position = align;
     }
 
+    /// Gets the alignment of the title
+    pub fn get_title_position(&self) -> HAlign {
+        self.title_position
+    }
+
     /// Sets the padding in the dialog (around content and buttons).
     ///
     /// # Examples

--- a/cursive-core/src/views/dialog.rs
+++ b/cursive-core/src/views/dialog.rs
@@ -333,6 +333,11 @@ impl Dialog {
         self.with(|s| s.set_padding(padding))
     }
 
+    /// Gets the padding in the dialog (around content and buttons).
+    pub fn get_padding(&self) -> Margins {
+        self.padding
+    }
+
     /// Sets the padding in the dialog.
     ///
     /// Takes Left, Right, Top, Bottom fields.
@@ -344,6 +349,18 @@ impl Dialog {
         bottom: usize,
     ) -> Self {
         self.padding(Margins::lrtb(left, right, top, bottom))
+    }
+
+    /// Gets the padding in the dialog.
+    ///
+    /// Returns Left, Right, Tob, Bottom fields as a tuple.
+    pub fn get_padding_lrtb(&self) -> (usize, usize, usize, usize) {
+        (
+            self.padding.left,
+            self.padding.right,
+            self.padding.top,
+            self.padding.bottom,
+        )
     }
 
     /// Sets the padding in the dialog (around content and buttons).
@@ -363,6 +380,11 @@ impl Dialog {
         self.padding.top = padding;
     }
 
+    /// Gets the top padding in the dialog (under the title).
+    pub fn get_padding_top(&mut self) -> usize {
+        self.padding.top
+    }
+
     /// Sets the bottom padding in the dialog (under buttons).
     pub fn padding_bottom(self, padding: usize) -> Self {
         self.with(|s| s.set_padding_bottom(padding))
@@ -371,6 +393,11 @@ impl Dialog {
     /// Sets the bottom padding in the dialog (under buttons).
     pub fn set_padding_bottom(&mut self, padding: usize) {
         self.padding.bottom = padding;
+    }
+
+    /// Gets the bottom padding in the dialog (under buttons).
+    pub fn get_padding_bottom(&mut self) -> usize {
+        self.padding.bottom
     }
 
     /// Sets the left padding in the dialog.
@@ -383,6 +410,11 @@ impl Dialog {
         self.padding.left = padding;
     }
 
+    /// Gets the left padding in the dialog.
+    pub fn get_padding_left(&mut self) -> usize {
+        self.padding.left
+    }
+
     /// Sets the right padding in the dialog.
     pub fn padding_right(self, padding: usize) -> Self {
         self.with(|s| s.set_padding_right(padding))
@@ -391,6 +423,11 @@ impl Dialog {
     /// Sets the right padding in the dialog.
     pub fn set_padding_right(&mut self, padding: usize) {
         self.padding.right = padding;
+    }
+
+    /// Gets the left padding in the dialog.
+    pub fn get_padding_right(&mut self) -> usize {
+        self.padding.right
     }
 
     /// Returns an iterator on this buttons for this dialog.

--- a/cursive-core/src/views/dialog.rs
+++ b/cursive-core/src/views/dialog.rs
@@ -437,23 +437,14 @@ impl Dialog {
     }
 
     /// Iterate the buttons of this dialog.
-    pub fn iter_buttons(&self) -> impl Iterator<Item = &Button> {
+    pub fn buttons(&self) -> impl Iterator<Item = &Button> {
         self.buttons.iter().map(|b| &b.button.view)
     }
 
     /// Mutably iterate the buttons of this dialog.
-    pub fn iter_buttons_mut(&mut self) -> impl Iterator<Item = &mut Button> {
+    pub fn buttons_mut(&mut self) -> impl Iterator<Item = &mut Button> {
         self.invalidate();
         self.buttons.iter_mut().map(|b| &mut b.button.view)
-    }
-
-    /// Mutably iterate the buttons of this dialog.
-    #[deprecated(
-        since = "0.2.2",
-        note = "Please use iter_buttons_mut instead"
-    )]
-    pub fn buttons_mut(&mut self) -> impl Iterator<Item = &mut Button> {
-        self.iter_buttons_mut()
     }
 
     /// Returns currently focused element

--- a/cursive-core/src/views/dialog.rs
+++ b/cursive-core/src/views/dialog.rs
@@ -441,6 +441,28 @@ impl Dialog {
         self.focus
     }
 
+    /// Change the current focus of the dialog.
+    ///
+    /// Please be considerate of the context from which focus is being stolen
+    /// when programmatically moving focus. For example, moving focus to a
+    /// button when a user is typing something into an `EditView` would cause
+    /// them to accidentally activate the button.
+    ///
+    /// The given dialog focus will be clamped to a valid range. For example,
+    /// attempting to focus a button that no longer exists will instead focus
+    /// one that does (or the content, if no buttons exist).
+    pub fn set_focus(&mut self, new_focus: DialogFocus) {
+        self.focus = match new_focus {
+            DialogFocus::Content => DialogFocus::Content,
+            DialogFocus::Button(_) if self.buttons.is_empty() => {
+                DialogFocus::Content
+            }
+            DialogFocus::Button(c) => {
+                DialogFocus::Button(max(c, self.buttons.len()))
+            }
+        }
+    }
+
     // Private methods
 
     // An event is received while the content is in focus


### PR DESCRIPTION
This PR adds a handful of new methods to allow access to internal Dialog properties that are currently write-only. It also adds some setters for previously read-only properties. The whole list is as follows:

- `replace_content`, which allows one to take the contents of a `Dialog` without destroying the `Dialog`
- `get_h_align`, which allows reading the current button row `HAlign`
- `get_title`, which allows reading the current title
- `get_title_position`, which allows reading the current title `HAlign`
- `get_padding`, `get_padding_lrtb`, `get_padding_left`, `get_padding_top`, `get_padding_right`, and `get_padding_bottom`, which allow reading the padding in every way you can currently set it
- `iter_buttons` for immutably reading the buttons on a `Dialog`
- `iter_buttons_mut`, which is intended to replace the now-deprecated `buttons_mut` as usual Rust convention is to have `iter` in the name of methods that yield values as an iterator
- `set_focus`, which allows stealing `Dialog` focus. (We clamp the values given to us for safety.)

You're free to veto any of these changes if you think they're excessive. (I suspect renaming `buttons_mut` might be going too far.)