### PR TITLE
Fix panic: Assume at least 8 colors available

### DIFF
--- a/cursive/src/backends/curses/mod.rs
+++ b/cursive/src/backends/curses/mod.rs
@@ -74,6 +74,7 @@ fn find_closest_pair(pair: ColorPair, max_colors: i16) -> (i16, i16) {
 /// If `max_colors` is less than 256 (like 8 or 16), the color will be
 /// downgraded to the closest one available.
 fn find_closest(color: Color, max_colors: i16) -> i16 {
+    let max_colors = std::cmp::max(max_colors, 8);
     match color {
         Color::TerminalDefault => -1,
         Color::Dark(BaseColor::Black) => 0,


### PR DESCRIPTION
Hi! We [received a report](https://forum.grin.mw/t/failed-to-start-a-new-grin-node/8413) of a panic in `cursive`:

`thread ‘main’ panicked at ‘attempt to calculate the remainder with a divisor of zero’: /home/cephd/.cargo/registry/src/mirrors.tuna.tsinghua.edu.cn-df7c3c540f42cdbd/cursive-0.15.0/src/backends/curses/mod.rs:93`

It looks like it's due to this line:

```rust
Color::Light(BaseColor::Black) => 8 % max_colors,
```

It appears that the `max_colors` value is being sourced from `ncurses::COLORS()`, which I can only assume is returning `0` for whatever reason.

Since the rest of the code looks as though it is written to assume at least 8 colors, this PR puts a lower bound of `8` on `max_colors` to prevent this panic.

Also happy to implement a different solution if you prefer!