### PR TITLE
Disable default enabled features

### DIFF
--- a/examples/Readme.md
+++ b/examples/Readme.md
@@ -8,7 +8,7 @@ To run an example, use `cargo run --bin EXAMPLE_NAME`.
 To use a specific cursive backend, you can do, for example:
 
 ```
-cargo run --bin EXAMPLE_NAME --features cursive/crossterm-backend
+cargo run --bin EXAMPLE_NAME --features cursive/crossterm-backend --no-default-features 
 ```
 
 ## [`hello_world`](src/bin/hello_world.rs)


### PR DESCRIPTION
When running crossterm-backend with this command, on linux, I will get an error that ncurses is not installed. By adding this, it works fine.