### PR TITLE
Add `Effect::Dim`

### DIFF
--- a/cursive-core/src/theme/effect.rs
+++ b/cursive-core/src/theme/effect.rs
@@ -8,6 +8,8 @@ pub enum Effect {
     Simple,
     /// Reverses foreground and background colors
     Reverse,
+    /// Prints foreground as "dim" or "faint" (has no effect for ncurses/pancurses/blt backends)
+    Dim,
     /// Prints foreground in bold
     Bold,
     /// Prints foreground in italic

--- a/cursive/src/backends/blt.rs
+++ b/cursive/src/backends/blt.rs
@@ -267,7 +267,8 @@ impl backend::Backend for Backend {
     fn set_effect(&self, effect: Effect) {
         match effect {
             // TODO: does BLT support bold/italic/strikethrough/underline?
-            Effect::Bold
+            Effect::Dim
+            | Effect::Bold
             | Effect::Italic
             | Effect::Underline
             | Effect::Strikethrough
@@ -286,7 +287,8 @@ impl backend::Backend for Backend {
     fn unset_effect(&self, effect: Effect) {
         match effect {
             // TODO: does BLT support bold/italic/strikethrough/underline?
-            Effect::Bold
+            Effect::Dim
+            | Effect::Bold
             | Effect::Italic
             | Effect::Underline
             | Effect::Strikethrough

--- a/cursive/src/backends/crossterm.rs
+++ b/cursive/src/backends/crossterm.rs
@@ -362,6 +362,7 @@ impl backend::Backend for Backend {
         match effect {
             theme::Effect::Simple => (),
             theme::Effect::Reverse => self.set_attr(Attribute::Reverse),
+            theme::Effect::Dim => self.set_attr(Attribute::Dim),
             theme::Effect::Bold => self.set_attr(Attribute::Bold),
             theme::Effect::Blink => self.set_attr(Attribute::SlowBlink),
             theme::Effect::Italic => self.set_attr(Attribute::Italic),
@@ -376,7 +377,7 @@ impl backend::Backend for Backend {
         match effect {
             theme::Effect::Simple => (),
             theme::Effect::Reverse => self.set_attr(Attribute::NoReverse),
-            theme::Effect::Bold => self.set_attr(Attribute::NormalIntensity),
+            theme::Effect::Dim | theme::Effect::Bold => self.set_attr(Attribute::NormalIntensity),
             theme::Effect::Blink => self.set_attr(Attribute::NoBlink),
             theme::Effect::Italic => self.set_attr(Attribute::NoItalic),
             theme::Effect::Strikethrough => {

--- a/cursive/src/backends/curses/n.rs
+++ b/cursive/src/backends/curses/n.rs
@@ -367,6 +367,7 @@ impl backend::Backend for Backend {
         let style = match effect {
             Effect::Reverse => ncurses::A_REVERSE(),
             Effect::Simple => ncurses::A_NORMAL(),
+            Effect::Dim => ncurses::A_DIM(),
             Effect::Bold => ncurses::A_BOLD(),
             Effect::Blink => ncurses::A_BLINK(),
             Effect::Italic => ncurses::A_ITALIC(),
@@ -380,6 +381,7 @@ impl backend::Backend for Backend {
         let style = match effect {
             Effect::Reverse => ncurses::A_REVERSE(),
             Effect::Simple => ncurses::A_NORMAL(),
+            Effect::Dim => ncurses::A_DIM(),
             Effect::Bold => ncurses::A_BOLD(),
             Effect::Blink => ncurses::A_BLINK(),
             Effect::Italic => ncurses::A_ITALIC(),

--- a/cursive/src/backends/curses/pan.rs
+++ b/cursive/src/backends/curses/pan.rs
@@ -411,6 +411,7 @@ impl backend::Backend for Backend {
         let style = match effect {
             Effect::Simple => pancurses::Attribute::Normal,
             Effect::Reverse => pancurses::Attribute::Reverse,
+            Effect::Dim => pancurses::Attribute::Dim,
             Effect::Bold => pancurses::Attribute::Bold,
             Effect::Blink => pancurses::Attribute::Blink,
             Effect::Italic => pancurses::Attribute::Italic,
@@ -424,6 +425,7 @@ impl backend::Backend for Backend {
         let style = match effect {
             Effect::Simple => pancurses::Attribute::Normal,
             Effect::Reverse => pancurses::Attribute::Reverse,
+            Effect::Dim => pancurses::Attribute::Dim,
             Effect::Bold => pancurses::Attribute::Bold,
             Effect::Blink => pancurses::Attribute::Blink,
             Effect::Italic => pancurses::Attribute::Italic,

--- a/cursive/src/backends/termion.rs
+++ b/cursive/src/backends/termion.rs
@@ -247,6 +247,7 @@ impl backend::Backend for Backend {
         match effect {
             theme::Effect::Simple => (),
             theme::Effect::Reverse => self.write(tstyle::Invert),
+            theme::Effect::Dim => self.write(tstyle::Faint),
             theme::Effect::Bold => self.write(tstyle::Bold),
             theme::Effect::Blink => self.write(tstyle::Blink),
             theme::Effect::Italic => self.write(tstyle::Italic),
@@ -259,7 +260,9 @@ impl backend::Backend for Backend {
         match effect {
             theme::Effect::Simple => (),
             theme::Effect::Reverse => self.write(tstyle::NoInvert),
-            theme::Effect::Bold => self.write(tstyle::NoFaint),
+            theme::Effect::Dim | theme::Effect::Bold => {
+                self.write(tstyle::NoFaint)
+            }
             theme::Effect::Blink => self.write(tstyle::NoBlink),
             theme::Effect::Italic => self.write(tstyle::NoItalic),
             theme::Effect::Strikethrough => self.write(tstyle::NoCrossedOut),


### PR DESCRIPTION
The effect is more useful on a different background color (e.g. on black background and white foreground, the dim effect produces gray text).

Tested using this code:

```rust
use cursive::theme::Effect;
use cursive::utils::markup::StyledString;
use cursive::views::{LinearLayout, TextView};
use cursive::CursiveRunnable;

fn main() {
    let backends: &[(&str, fn() -> CursiveRunnable)] = &[
        ("ncurses", cursive::ncurses),
        ("pancurses", cursive::pancurses),
        ("crossterm", cursive::crossterm),
        ("termion", cursive::termion),
    ];
    for (backend_name, backend) in backends {
        let mut siv = backend().into_runner();
        siv.add_layer(
            LinearLayout::vertical()
                .child(TextView::new(format!(
                    "This is normal text from backend: {}",
                    backend_name
                )))
                .child(TextView::new({
                    let mut s = StyledString::styled("This is bold text ", Effect::Bold);
                    s.append_plain("followed by normal text");
                    s
                }))
                .child(TextView::new({
                    let mut s = StyledString::styled("This is dim text ", Effect::Dim);
                    s.append_plain("followed by normal text");
                    s
                })),
        );
        siv.run();
    }
}
```

It produced the following output (no effect for ncurses/pancurses):

<img width="698" alt="ncurses test (not rendered)" src="https://user-images.githubusercontent.com/454057/118414464-b68aaa80-b672-11eb-9247-8969cb2ba500.png">
<img width="698" alt="pancurses test (not rendered)" src="https://user-images.githubusercontent.com/454057/118414465-b7234100-b672-11eb-9b79-4ce3fcbd57cb.png">
<img width="698" alt="crossterm test (successfully rendered)" src="https://user-images.githubusercontent.com/454057/118414467-b7234100-b672-11eb-98ca-6fbce419a35f.png">
<img width="698" alt="termion test (successfully rendered)" src="https://user-images.githubusercontent.com/454057/118414468-b7234100-b672-11eb-8974-3c7190053fdd.png">
