### PR TITLE
Fix Align::bot_right

### DIFF
--- a/cursive-core/src/align.rs
+++ b/cursive-core/src/align.rs
@@ -37,7 +37,7 @@ impl Align {
 
     /// Creates a bottom-right alignment.
     pub fn bot_right() -> Self {
-        Align::new(HAlign::Right, VAlign::Top)
+        Align::new(HAlign::Right, VAlign::Bottom)
     }
 
     /// Creates a bottom-center alignment.


### PR DESCRIPTION
The `Align::bot_right` method created a top right alignment before. This patch changes this to produce
the correct struct variant.

Just found this while writing a few tests, seems to have been a small copy paste error :smile: 