### PR TITLE
Fix crates.io shield

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 # Cursive
 
-[![crates.io](https://meritbadge.herokuapp.com/cursive)](https://crates.io/crates/cursive)
+[![crates.io](https://img.shields.io/crates/v/cursive.svg)](https://crates.io/crates/cursive)
 [![Rust](https://github.com/gyscos/cursive/actions/workflows/rust.yml/badge.svg?branch=main)](https://github.com/gyscos/cursive/actions/workflows/rust.yml)
 [![Build status (appveyor)](https://ci.appveyor.com/api/projects/status/uk5pww718jsp5x2l/branch/main?svg=true)](https://ci.appveyor.com/project/gyscos/cursive/branch/main)
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)


### PR DESCRIPTION
The current source for the icon is offline