### PR TITLE
Remove all 'needless borrows' Clippy complains about

### DIFF
--- a/cursive-core/src/cursive.rs
+++ b/cursive-core/src/cursive.rs
@@ -135,7 +135,7 @@ impl Cursive {
         if self.menubar.visible() {
             let printer = printer.focused(self.menubar.receive_events());
             printer.with_color(theme::ColorStyle::primary(), |printer| {
-                self.menubar.draw(&printer)
+                self.menubar.draw(printer)
             });
         }
 

--- a/cursive-core/src/views/menu_popup.rs
+++ b/cursive-core/src/views/menu_popup.rs
@@ -324,7 +324,7 @@ impl View for MenuPopup {
         // Start with a box
         scroll::draw_box_frame(
             self,
-            &printer,
+            printer,
             |s, y| s.menu.children[y].is_delimiter(),
             |_s, _x| false,
         );

--- a/cursive-core/src/views/panel.rs
+++ b/cursive-core/src/views/panel.rs
@@ -112,7 +112,7 @@ impl<V: View> ViewWrapper for Panel<V> {
 
     fn wrap_draw(&self, printer: &Printer) {
         printer.print_box((0, 0), printer.size, true);
-        self.draw_title(&printer);
+        self.draw_title(printer);
 
         let printer = printer.offset((1, 1)).shrinked((1, 1));
         self.view.draw(&printer);

--- a/cursive/src/backends/crossterm.rs
+++ b/cursive/src/backends/crossterm.rs
@@ -377,7 +377,9 @@ impl backend::Backend for Backend {
         match effect {
             theme::Effect::Simple => (),
             theme::Effect::Reverse => self.set_attr(Attribute::NoReverse),
-            theme::Effect::Dim | theme::Effect::Bold => self.set_attr(Attribute::NormalIntensity),
+            theme::Effect::Dim | theme::Effect::Bold => {
+                self.set_attr(Attribute::NormalIntensity)
+            }
             theme::Effect::Blink => self.set_attr(Attribute::NoBlink),
             theme::Effect::Italic => self.set_attr(Attribute::NoItalic),
             theme::Effect::Strikethrough => {

--- a/cursive/src/backends/puppet/observed.rs
+++ b/cursive/src/backends/puppet/observed.rs
@@ -281,7 +281,7 @@ pub trait ObservedPieceInterface {
                 match &self.parent()[Vec2::new(x, y)] {
                     None => s.push(' '),
                     Some(cell) => {
-                        if let GraphemePart::Begin(lex) = &cell.letter {
+                        if let GraphemePart::Begin(ref lex) = cell.letter {
                             s.push_str(lex);
                         }
                     }

--- a/cursive/src/backends/puppet/observed.rs
+++ b/cursive/src/backends/puppet/observed.rs
@@ -282,7 +282,7 @@ pub trait ObservedPieceInterface {
                     None => s.push(' '),
                     Some(cell) => {
                         if let GraphemePart::Begin(lex) = &cell.letter {
-                            s.push_str(&lex);
+                            s.push_str(lex);
                         }
                     }
                 }


### PR DESCRIPTION
This removes [`needless_borrow`](https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow) warnings.