### PR TITLE
Add Dialog the capability to be focusable

### DIFF
--- a/cursive-core/src/views/panel.rs
+++ b/cursive-core/src/views/panel.rs
@@ -72,7 +72,7 @@ impl<V> Panel<V> {
                 + self
                     .title_position
                     .get_offset(len, printer.size.x - 2 * TITLE_SPACING);
-            printer.with_high_border(false, |printer| {
+            printer.with_high_border(false, false, |printer| {
                 printer.print((x - 2, 0), "┤ ");
                 printer.print((x + len, 0), " ├");
             });
@@ -111,7 +111,7 @@ impl<V: View> ViewWrapper for Panel<V> {
     }
 
     fn wrap_draw(&self, printer: &Printer) {
-        printer.print_box((0, 0), printer.size, true);
+        printer.print_box((0, 0), printer.size, true, false);
         self.draw_title(printer);
 
         let printer = printer.offset((1, 1)).shrinked((1, 1));

--- a/cursive/examples/focusable_dialog.rs
+++ b/cursive/examples/focusable_dialog.rs
@@ -1,0 +1,76 @@
+use cursive::theme::*;
+use cursive::views::*;
+use cursive::{
+    views::{CircularFocus, Dialog, TextView},
+    With as _,
+};
+
+fn main() {
+    // Creates the cursive root - required for every application.
+    let mut siv = cursive::default();
+
+    // Creates a dialog with a single "Quit" button
+    siv.add_layer(
+        // Most views can be configured in a chainable way
+        LinearLayout::vertical()
+            .child(
+                LinearLayout::horizontal()
+                    .child(
+                        Dialog::around(TextView::new("Select border theme"))
+                            .title("Cursive")
+                            .focusable(true)
+                            .focus_callback(|s| {
+                                s.update_theme(|t| match t.borders {
+                                    BorderStyle::Simple => {
+                                        t.borders = BorderStyle::Outset
+                                    }
+                                    BorderStyle::Outset => {
+                                        t.borders = BorderStyle::None
+                                    }
+                                    BorderStyle::None => {
+                                        t.borders = BorderStyle::Simple
+                                    }
+                                })
+                            })
+                            .button("Simple", |s| {
+                                s.update_theme(|t| {
+                                    t.borders = BorderStyle::Simple
+                                })
+                            })
+                            .button("Outset", |s| {
+                                s.update_theme(|t| {
+                                    t.borders = BorderStyle::Outset
+                                })
+                            })
+                            .button("None", |s| {
+                                s.update_theme(|t| {
+                                    t.borders = BorderStyle::None
+                                })
+                            })
+                            .wrap_with(CircularFocus::new)
+                            .wrap_tab(),
+                    )
+                    .child(
+                        Dialog::around(EditView::new().on_submit(|_, _| ()))
+                            .title("Cursive")
+                            .focusable(true)
+                            .button("Foo", |_s| ())
+                            .button("Quit", |s| s.quit())
+                            .wrap_with(CircularFocus::new)
+                            .wrap_tab(),
+                    ),
+            )
+            .child(
+                Dialog::around(TextView::new("Hello Dialog!"))
+                    .title("Cursive")
+                    .focusable(true)
+                    .button("Foo", |_s| ())
+                    .button("Quit", |s| s.quit())
+                    .wrap_with(CircularFocus::new)
+                    .wrap_tab(),
+            ),
+    );
+
+    // Starts the event loop.
+    siv.run();
+}


### PR DESCRIPTION
Hello!

I found this feature missing: you can set a dialog to be "focusable". This
means you can focus on the dialog itself, it will take the title primary color
and it can take a callback function.

The callback function is optional: if you don't use the callback, pressing
enter will give the focus to the content of the dialog.

If you press Tab or Shift+Tab it will start focusing the buttons instead.

This is similar to the "interactive" feature of the component
[Card](https://blueprintjs.com/docs/#core/components/card) of Blueprint.js

I will use it to make a new CLI for my library
[gptman](https://github.com/cecton/gptman/).
