### PR TITLE
Clarify that weight is currently unused by LinearLayout

### DIFF
--- a/cursive-core/src/views/linear_layout.rs
+++ b/cursive-core/src/views/linear_layout.rs
@@ -147,7 +147,7 @@ impl LinearLayout {
         }
     }
 
-    /// Sets the weight of the given child.
+    /// Sets the weight of the given child. This weight is currently unused by the layout process.
     ///
     /// # Panics
     ///
@@ -156,7 +156,7 @@ impl LinearLayout {
         self.children[i]._weight = weight;
     }
 
-    /// Modifies the weight of the last child added.
+    /// Modifies the weight of the last child added. This weight is currently unused by the layout process.
     ///
     /// It is an error to call this before adding a child (and it will panic).
     pub fn weight(mut self, weight: usize) -> Self {


### PR DESCRIPTION
According to [this comment](https://github.com/gyscos/cursive/issues/370#issuecomment-524979221) from a few years back on #370, the weight values for children of `LinearLayout` currently aren't used in the layout process, and looking at the source code, that appears to still be true. In this case, I think it would be helpful to note that in the method docs.