### PR TITLE
scroll: in strict mode, fill non-scrolling axis

### DIFF
--- a/cursive-core/src/view/scroll/raw.rs
+++ b/cursive-core/src/view/scroll/raw.rs
@@ -60,7 +60,11 @@ where
     // Where we're not, just forward inner_size.
     let size = get_scroller(model).is_enabled().select_or(
         Vec2::min(inner_size + scrollbar_size, constraint),
-        inner_size + scrollbar_size,
+        // In strict mode, fill all the space we can:
+        match strict {
+            true => constraint,
+            false => inner_size + scrollbar_size,
+        }
     );
 
     // In strict mode, there's no way our size is over constraints.


### PR DESCRIPTION
Non-scrolling axes wouldn't expand to fill their parent otherwise.

See also: https://github.com/ComputerScienceHouse/clink/pull/18

Without this change, the `SelectView` I put in my `Dialog` doesn't expand to fill the much wider `Dialog`