### PR TITLE
Fix Printer class member 'content_offset' naming

### DIFF
--- a/cursive-core/src/view/mod.rs
+++ b/cursive-core/src/view/mod.rs
@@ -65,7 +65,7 @@
 //!
 //! In some cases however it may be interesting for the nested view to know
 //! about this, maybe to avoid computing parts of the view that are not
-//! visible. `Printer::output_size` and `Printer::content_offset` can be used
+//! visible. `Printer::output_size` and `Printer::drawing_area_offset` can be used
 //! to find out what part of the view should actually be printed.
 //!
 //! ## Important Area

--- a/cursive-core/src/view/scroll/mod.rs
+++ b/cursive-core/src/view/scroll/mod.rs
@@ -185,7 +185,7 @@ pub fn draw_lines<T, LineDrawer>(
     LineDrawer: FnMut(&T, &Printer, usize),
 {
     draw(scroller, printer, |s, printer| {
-        let start = printer.content_offset.y;
+        let start = printer.drawing_area_offset.y;
         let end = start + printer.output_size.y;
         for y in start..end {
             let printer = printer.offset((0, y)).cropped((printer.size.x, 1));

--- a/cursive-core/src/views/text_view.rs
+++ b/cursive-core/src/views/text_view.rs
@@ -407,7 +407,7 @@ impl View for TextView {
                 .rows
                 .iter()
                 .enumerate()
-                .skip(printer.content_offset.y)
+                .skip(printer.drawing_area_offset.y)
                 .take(printer.output_size.y)
             {
                 let l = row.width;


### PR DESCRIPTION
Replace "content_offset" by "drawing_area_offset".