### PR TITLE
tweaked two docs tests

### DIFF
--- a/cursive-core/src/printer.rs
+++ b/cursive-core/src/printer.rs
@@ -132,8 +132,8 @@ impl<'a, 'b> Printer<'a, 'b> {
     /// The text could be truncated if it exceed the [drawing area size](Self::output_size).
     ///
     /// # Example
-    /// ```ignore
-    /// use cursive::{Printer, Vec2, View, XY};
+    /// ```rust
+    /// use cursive_core::{Printer, Vec2, View, XY};
     ///
     /// pub struct CustomView {
     ///     word: String,

--- a/cursive-core/src/printer.rs
+++ b/cursive-core/src/printer.rs
@@ -132,7 +132,7 @@ impl<'a, 'b> Printer<'a, 'b> {
     /// The text could be truncated if it exceed the [drawing area size](Self::output_size).
     ///
     /// # Example
-    /// ```rust
+    /// ```ignore
     /// use cursive::{Printer, Vec2, View, XY};
     ///
     /// pub struct CustomView {

--- a/cursive-core/src/view/any.rs
+++ b/cursive-core/src/view/any.rs
@@ -20,7 +20,7 @@ pub trait AnyView {
     /// ```rust
     /// # use cursive_core::views::TextView;
     /// # use cursive_core::view::View;
-    /// let boxed: Box<View> = Box::new(TextView::new("text"));
+    /// let boxed: Box<dyn View> = Box::new(TextView::new("text"));
     /// let text: Box<TextView> = boxed.as_boxed_any().downcast().unwrap();
     /// ```
     fn as_boxed_any(self: Box<Self>) -> Box<dyn Any>;


### PR DESCRIPTION
The test in printer.rs used items from cursive, and depending on cursive from cursive-core would create a dependency circle, so this example was annotated with ignore. 

The test in view/any.rs was missing a 'dyn' keyword, just added that.