### PR TITLE
Reset Cursive::running flag in runner(), not try_run_with()

### DIFF
--- a/cursive-core/src/cursive.rs
+++ b/cursive-core/src/cursive.rs
@@ -882,6 +882,7 @@ impl Cursive {
         &mut self,
         backend: Box<dyn backend::Backend>,
     ) -> CursiveRunner<&mut Self> {
+        self.running = true;
         CursiveRunner::new(self, backend)
     }
 
@@ -916,7 +917,6 @@ impl Cursive {
     where
         F: FnOnce() -> Result<Box<dyn backend::Backend>, E>,
     {
-        self.running = true;
         let mut runner = self.runner(backend_init()?);
 
         runner.run();


### PR DESCRIPTION
The current setup only enables running the event loop multiple times with the high-level run() function. When using the manual runner() harness, any runner created after the first run will exit immediately because the running flag has been cleared by the first run and not set back on when the new runner is created.

I don't think that's the intended behavior, but if it is please tell me where I should add a way to reset the self.running flag in order to be able to use multiple runners.