### PR TITLE
Add `invert` method to `ColorStyle`

### DIFF
--- a/cursive-core/src/theme/color_style.rs
+++ b/cursive-core/src/theme/color_style.rs
@@ -44,6 +44,15 @@ impl ColorStyle {
         Self::new(ColorType::InheritParent, back)
     }
 
+    /// Returns an inverted color style, with the front and back colors swapped.
+    #[must_use]
+    pub fn invert(self) -> Self {
+        ColorStyle {
+            front: self.back,
+            back: self.front,
+        }
+    }
+
     /// Uses `ColorType::InheritParent` for both front and background.
     pub fn inherit_parent() -> Self {
         Self::new(ColorType::InheritParent, ColorType::InheritParent)


### PR DESCRIPTION
I added a simple method in my `cursive`-using project to do this, but I figured it would be helpful to add this upstream as a method on `ColorStyle`. Followed the same pattern as `ColorPair::invert`.