### PR TITLE
checkbox: remove missing method from example

### DIFF
--- a/cursive-core/src/views/checkbox.rs
+++ b/cursive-core/src/views/checkbox.rs
@@ -17,7 +17,7 @@ type Callback = dyn Fn(&mut Cursive, bool);
 /// use cursive_core::traits::Nameable;
 /// use cursive_core::views::Checkbox;
 ///
-/// let checkbox = Checkbox::new().checked().with_name("check");
+/// let checkbox = Checkbox::new().checked();
 /// ```
 pub struct Checkbox {
     checked: bool,


### PR DESCRIPTION
The with_name method is not part of the checkbox view and therefore, the provided example does not work.