### PR TITLE
Reset focus field when clearing LinearLayout

### DIFF
--- a/cursive-core/src/views/linear_layout.rs
+++ b/cursive-core/src/views/linear_layout.rs
@@ -287,6 +287,7 @@ impl LinearLayout {
     pub fn clear(&mut self) {
         self.invalidate();
         self.children.clear();
+        self.focus = 0;
     }
 
     /// Removes a child.


### PR DESCRIPTION
The focus field should be reset to the default value when clearing the LinearLayout view.