### PR TITLE
Add basic features to CursiveLogger

### DIFF
--- a/cursive-core/Cargo.toml
+++ b/cursive-core/Cargo.toml
@@ -24,7 +24,7 @@ repository = "gyscos/cursive"
 [dependencies]
 enum-map = "2.0"
 enumset = "1.0.4"
-log = { version = "0.4", features = ["std"] }
+log = "0.4"
 owning_ref = "0.4"
 unicode-segmentation = "1"
 unicode-width = "0.1"

--- a/cursive-core/Cargo.toml
+++ b/cursive-core/Cargo.toml
@@ -24,7 +24,7 @@ repository = "gyscos/cursive"
 [dependencies]
 enum-map = "2.0"
 enumset = "1.0.4"
-log = "0.4"
+log = { version = "0.4", features = ["std"] }
 owning_ref = "0.4"
 unicode-segmentation = "1"
 unicode-width = "0.1"

--- a/cursive-core/src/logger.rs
+++ b/cursive-core/src/logger.rs
@@ -33,6 +33,12 @@ use std::sync::{Mutex, RwLock};
 pub struct CursiveLogger;
 
 lazy_static! {
+    /// Circular buffer for logs. Use it to implement [`DebugView`].
+    ///
+    /// [`DebugView`]: ../views/struct.DebugView.html
+    pub static ref LOGS: Mutex<VecDeque<Record>> =
+        Mutex::new(VecDeque::new());
+
     // Log filter level for log messages from within cursive
     static ref INT_FILTER_LEVEL: RwLock<log::LevelFilter> = RwLock::new(log::LevelFilter::Trace);
     // Log filter level for log messages from sources outside of cursive
@@ -75,14 +81,6 @@ pub struct Record {
     pub time: time::OffsetDateTime,
     /// Message content
     pub message: String,
-}
-
-lazy_static! {
-    /// Circular buffer for logs. Use it to implement [`DebugView`].
-    ///
-    /// [`DebugView`]: ../views/struct.DebugView.html
-    pub static ref LOGS: Mutex<VecDeque<Record>> =
-        Mutex::new(VecDeque::new());
 }
 
 /// Log a record in cursive's log queue.

--- a/cursive-core/src/logger.rs
+++ b/cursive-core/src/logger.rs
@@ -16,7 +16,7 @@ use std::sync::{Mutex, RwLock};
 ///
 /// ```
 /// # use cursive_core::*;
-/// logger::set_filter_levels_with_env();
+/// logger::set_filter_levels_from_env();
 /// logger::init();
 /// ```
 ///
@@ -53,7 +53,7 @@ pub fn set_ext_filter_level(level: log::LevelFilter) {
 /// If `RUST_LOG` is set, then both internal and external log levels are set to match.
 /// If `CURSIVE_LOG` is set, then the internal log level is set to match with precedence over
 /// `RUST_LOG`.
-pub fn set_filter_levels_with_env() {
+pub fn set_filter_levels_from_env() {
     if let Ok(rust_log) = std::env::var("RUST_LOG") {
         if let Ok(filter_level) = log::LevelFilter::from_str(&rust_log) {
             set_int_filter_level(filter_level);

--- a/cursive-core/src/logger.rs
+++ b/cursive-core/src/logger.rs
@@ -61,14 +61,20 @@ pub fn set_external_filter_level(level: log::LevelFilter) {
 /// `RUST_LOG`.
 pub fn set_filter_levels_from_env() {
     if let Ok(rust_log) = std::env::var("RUST_LOG") {
-        if let Ok(filter_level) = log::LevelFilter::from_str(&rust_log) {
-            set_internal_filter_level(filter_level);
-            set_external_filter_level(filter_level);
+        match log::LevelFilter::from_str(&rust_log) {
+            Ok(filter_level) => {
+                set_internal_filter_level(filter_level);
+                set_external_filter_level(filter_level);
+            }
+            Err(e) => log::warn!("Could not parse RUST_LOG: {}", e),
         }
     }
     if let Ok(cursive_log) = std::env::var("CURSIVE_LOG") {
-        if let Ok(filter_level) = log::LevelFilter::from_str(&cursive_log) {
-            set_internal_filter_level(filter_level);
+        match log::LevelFilter::from_str(&cursive_log) {
+            Ok(filter_level) => {
+                set_internal_filter_level(filter_level);
+            }
+            Err(e) => log::warn!("Could not parse CURSIVE_LOG: {}", e),
         }
     }
 }

--- a/cursive-core/src/logger.rs
+++ b/cursive-core/src/logger.rs
@@ -4,7 +4,7 @@ use lazy_static::lazy_static;
 use std::cmp::Ord;
 use std::collections::VecDeque;
 use std::str::FromStr;
-use std::sync::Mutex;
+use std::sync::{Mutex, RwLock};
 
 /// Saves all log records in a global deque.
 ///
@@ -15,93 +15,55 @@ use std::sync::Mutex;
 /// Set log levels from env vars
 ///
 /// ```
-/// # use cursive_core::logger::CursiveLogger;
-/// CursiveLogger::new()
-///     .with_env()
-///     .init();
+/// # use cursive_core::*;
+/// logger::set_filter_levels_with_env();
+/// logger::init();
 /// ```
 ///
 /// Set log levels explicitly.
 ///
 /// ```
-/// # use cursive_core::logger::CursiveLogger;
+/// # use cursive_core::*;
 /// # use log::LevelFilter;
-/// CursiveLogger::new()
-///     .with_int_filter_level(LevelFilter::Warn)
-///     .with_ext_filter_level(LevelFilter::Debug)
-///     .init();
+/// logger::set_int_filter_level(LevelFilter::Warn);
+/// logger::set_ext_filter_level(LevelFilter::Debug);
+/// logger::init();
 /// ```
-///
-/// Set log queue size.
-///
-/// ```
-/// # use cursive_core::logger::CursiveLogger;
-/// CursiveLogger::new()
-///     .with_log_size(10_000)
-///     .init();
-/// ```
-pub struct CursiveLogger {
+
+pub struct CursiveLogger;
+
+lazy_static! {
     // Log filter level for log messages from within cursive
-    int_filter_level: log::LevelFilter,
+    static ref INT_FILTER_LEVEL: RwLock<log::LevelFilter> = RwLock::new(log::LevelFilter::Trace);
     // Log filter level for log messages from sources outside of cursive
-    ext_filter_level: log::LevelFilter,
-    // Size of log queue
-    log_size: usize,
+    static ref EXT_FILTER_LEVEL: RwLock<log::LevelFilter> = RwLock::new(log::LevelFilter::Trace);
 }
 
-impl CursiveLogger {
-    /// Creates a new CursiveLogger with default log filter levels of `log::LevelFilter::Trace`.
-    /// Remember to call `init()` to install with `log` backend.
-    pub fn new() -> Self {
-        CursiveLogger {
-            int_filter_level: log::LevelFilter::Trace,
-            ext_filter_level: log::LevelFilter::Trace,
-            log_size: 1000,
+/// Sets the internal log filter level.
+pub fn set_int_filter_level(level: log::LevelFilter) {
+    *INT_FILTER_LEVEL.write().unwrap() = level;
+}
+
+/// Sets the external log filter level.
+pub fn set_ext_filter_level(level: log::LevelFilter) {
+    *EXT_FILTER_LEVEL.write().unwrap() = level;
+}
+
+/// Sets log filter levels based on environment variables `RUST_LOG` and `CURSIVE_LOG`.
+/// If `RUST_LOG` is set, then both internal and external log levels are set to match.
+/// If `CURSIVE_LOG` is set, then the internal log level is set to match with precedence over
+/// `RUST_LOG`.
+pub fn set_filter_levels_with_env() {
+    if let Ok(rust_log) = std::env::var("RUST_LOG") {
+        if let Ok(filter_level) = log::LevelFilter::from_str(&rust_log) {
+            set_int_filter_level(filter_level);
+            set_ext_filter_level(filter_level);
         }
     }
-
-    /// Sets the internal log filter level.
-    pub fn with_int_filter_level(mut self, level: log::LevelFilter) -> Self {
-        self.int_filter_level = level;
-        self
-    }
-
-    /// Sets the external log filter level.
-    pub fn with_ext_filter_level(mut self, level: log::LevelFilter) -> Self {
-        self.ext_filter_level = level;
-        self
-    }
-
-    /// Sets log filter levels based on environment variables `RUST_LOG` and `CURSIVE_LOG`.
-    /// If `RUST_LOG` is set, then both internal and external log levels are set to match.
-    /// If `CURSIVE_LOG` is set, then the internal log level is set to match with precedence over
-    /// `RUST_LOG`.
-    pub fn with_env(mut self) -> Self {
-        if let Ok(rust_log) = std::env::var("RUST_LOG") {
-            if let Ok(filter_level) = log::LevelFilter::from_str(&rust_log) {
-                self.int_filter_level = filter_level;
-                self.ext_filter_level = filter_level;
-            }
+    if let Ok(cursive_log) = std::env::var("CURSIVE_LOG") {
+        if let Ok(filter_level) = log::LevelFilter::from_str(&cursive_log) {
+            set_int_filter_level(filter_level);
         }
-        if let Ok(cursive_log) = std::env::var("CURSIVE_LOG") {
-            if let Ok(filter_level) = log::LevelFilter::from_str(&cursive_log) {
-                self.int_filter_level = filter_level;
-            }
-        }
-        self
-    }
-
-    /// Sets the size of the log queue
-    pub fn with_log_size(mut self, log_size: usize) -> Self {
-        self.log_size = log_size;
-        self
-    }
-
-    /// Installs the logger with log. Calling twice will panic.
-    pub fn init(self) {
-        reserve_logs(self.log_size);
-        log::set_max_level(self.int_filter_level.max(self.ext_filter_level));
-        log::set_boxed_logger(Box::new(self)).unwrap();
     }
 }
 
@@ -140,9 +102,9 @@ pub fn log(record: &log::Record) {
 impl log::Log for CursiveLogger {
     fn enabled(&self, metadata: &log::Metadata) -> bool {
         if metadata.target().starts_with("cursive_core::") {
-            metadata.level() <= self.int_filter_level
+            metadata.level() <= *INT_FILTER_LEVEL.read().unwrap()
         } else {
-            metadata.level() <= self.ext_filter_level
+            metadata.level() <= *EXT_FILTER_LEVEL.read().unwrap()
         }
     }
 
@@ -162,8 +124,13 @@ impl log::Log for CursiveLogger {
 /// Use a [`DebugView`](crate::views::DebugView) to see the logs, or use
 /// [`Cursive::toggle_debug_console()`](crate::Cursive::toggle_debug_console()).
 pub fn init() {
+    // ensure that the log queue capacity has been set
+    if LOGS.lock().unwrap().capacity() == 0 {
+        reserve_logs(1_000);
+    }
+    log::set_max_level((*INT_FILTER_LEVEL.read().unwrap()).max(*EXT_FILTER_LEVEL.read().unwrap()));
     // This will panic if `set_logger` was already called.
-    CursiveLogger::new().init();
+    log::set_logger(&CursiveLogger).unwrap();
 }
 
 /// Return a logger that stores records in cursive's log queue.
@@ -172,7 +139,11 @@ pub fn init() {
 ///
 /// An easier alternative might be to use [`init()`].
 pub fn get_logger() -> CursiveLogger {
-    CursiveLogger::new()
+    // ensure that the log queue capacity has been set
+    if LOGS.lock().unwrap().capacity() == 0 {
+        reserve_logs(1_000);
+    }
+    CursiveLogger
 }
 
 /// Adds `n` more entries to cursive's log queue.

--- a/cursive-core/src/logger.rs
+++ b/cursive-core/src/logger.rs
@@ -101,7 +101,7 @@ impl CursiveLogger {
     pub fn init(self) {
         reserve_logs(self.log_size);
         log::set_max_level(self.int_filter_level.max(self.ext_filter_level));
-        log::set_logger(Box::leak(Box::new(self))).unwrap();
+        log::set_boxed_logger(Box::new(self)).unwrap();
     }
 }
 

--- a/cursive-core/src/logger.rs
+++ b/cursive-core/src/logger.rs
@@ -1,6 +1,7 @@
 //! Logging utilities.
 
 use lazy_static::lazy_static;
+use std::cmp::Ord;
 use std::collections::VecDeque;
 use std::str::FromStr;
 use std::sync::Mutex;
@@ -99,8 +100,8 @@ impl CursiveLogger {
     /// Installs the logger with log. Calling twice will panic.
     pub fn init(self) {
         reserve_logs(self.log_size);
+        log::set_max_level(self.int_filter_level.max(self.ext_filter_level));
         log::set_logger(Box::leak(Box::new(self))).unwrap();
-        log::set_max_level(log::LevelFilter::Trace);
     }
 }
 

--- a/cursive-core/src/logger.rs
+++ b/cursive-core/src/logger.rs
@@ -76,7 +76,7 @@ impl CursiveLogger {
     /// calling twice will panic
     pub fn init(self) {
         reserve_logs(self.log_size);
-        log::set_boxed_logger(Box::new(self)).unwrap();
+        log::set_logger(Box::leak(Box::new(self))).unwrap();
         log::set_max_level(log::LevelFilter::Trace);
     }
 }

--- a/cursive-core/src/logger.rs
+++ b/cursive-core/src/logger.rs
@@ -7,12 +7,43 @@ use std::sync::Mutex;
 /// Saves all log records in a global deque.
 ///
 /// Uses a `DebugView` to access it.
+///
+/// # Examples
+///
+/// Set log levels from env vars
+///
+/// ```
+/// # use cursive_core::logger::CursiveLogger;
+/// CursiveLogger::new()
+///     .with_env()
+///     .init();
+/// ```
+///
+/// Set log levels explicitly.
+///
+/// ```
+/// # use cursive_core::logger::CursiveLogger;
+/// # use log::LevelFilter;
+/// CursiveLogger::new()
+///     .with_int_filter_level(LevelFilter::Warn)
+///     .with_ext_filter_level(LevelFilter::Debug)
+///     .init();
+/// ```
+///
+/// Set log queue size.
+///
+/// ```
+/// # use cursive_core::logger::CursiveLogger;
+/// CursiveLogger::new()
+///     .with_log_size(10_000)
+///     .init();
+/// ```
 pub struct CursiveLogger {
-    /// Log filter level for log messages from within cursive
+    // Log filter level for log messages from within cursive
     int_filter_level: log::LevelFilter,
-    /// Log filter level for log messages from sources outside of cursive
+    // Log filter level for log messages from sources outside of cursive
     ext_filter_level: log::LevelFilter,
-    /// Size of log queue
+    // Size of log queue
     log_size: usize
 }
 
@@ -34,10 +65,8 @@ fn get_env_log_level(env_var_name: &str) -> Option<log::LevelFilter> {
 }
 
 impl CursiveLogger {
-    /// Creates a new CursiveLogger with default log filter levels of log::LevelFilter::Trace
-    /// If RUST_LOG is set, then both internal and external log levels are set to match
-    /// If CURSIVE_LOG is set, then the internal log level is set to match
-    /// Remember to call `init()` to install with `log` backend
+    /// Creates a new CursiveLogger with default log filter levels of `log::LevelFilter::Trace`.
+    /// Remember to call `init()` to install with `log` backend.
     pub fn new() -> Self {
         CursiveLogger {
             int_filter_level: log::LevelFilter::Trace,
@@ -46,19 +75,22 @@ impl CursiveLogger {
         }
     }
 
-    /// sets the internal log filter level
+    /// Sets the internal log filter level.
     pub fn with_int_filter_level(mut self, level: log::LevelFilter) -> Self {
         self.int_filter_level = level;
         self
     }
 
-    /// sets the external log filter level
+    /// Sets the external log filter level.
     pub fn with_ext_filter_level(mut self, level: log::LevelFilter) -> Self {
         self.ext_filter_level = level;
         self
     }
 
-    /// sets log filter levels based on environment variables `RUST_LOG` and `CURSIVE_LOG`
+    /// Sets log filter levels based on environment variables `RUST_LOG` and `CURSIVE_LOG`.
+    /// If `RUST_LOG` is set, then both internal and external log levels are set to match.
+    /// If `CURSIVE_LOG` is set, then the internal log level is set to match with precedence over
+    /// `RUST_LOG`.
     pub fn with_env(mut self) -> Self {
         if let Some(filter_level) = get_env_log_level("RUST_LOG") {
             self.int_filter_level = filter_level;
@@ -70,14 +102,13 @@ impl CursiveLogger {
         self
     }
 
-    /// sets the size of the log queue
+    /// Sets the size of the log queue
     pub fn with_log_size(mut self, log_size: usize) -> Self {
         self.log_size = log_size;
         self
     }
 
-    /// installs the logger with log
-    /// calling twice will panic
+    /// Installs the logger with log. Calling twice will panic.
     pub fn init(self) {
         reserve_logs(self.log_size);
         log::set_logger(Box::leak(Box::new(self))).unwrap();

--- a/cursive-core/src/logger.rs
+++ b/cursive-core/src/logger.rs
@@ -25,8 +25,8 @@ use std::sync::{Mutex, RwLock};
 /// ```
 /// # use cursive_core::*;
 /// # use log::LevelFilter;
-/// logger::set_int_filter_level(LevelFilter::Warn);
-/// logger::set_ext_filter_level(LevelFilter::Debug);
+/// logger::set_internal_filter_level(LevelFilter::Warn);
+/// logger::set_external_filter_level(LevelFilter::Debug);
 /// logger::init();
 /// ```
 
@@ -40,12 +40,12 @@ lazy_static! {
 }
 
 /// Sets the internal log filter level.
-pub fn set_int_filter_level(level: log::LevelFilter) {
+pub fn set_internal_filter_level(level: log::LevelFilter) {
     *INT_FILTER_LEVEL.write().unwrap() = level;
 }
 
 /// Sets the external log filter level.
-pub fn set_ext_filter_level(level: log::LevelFilter) {
+pub fn set_external_filter_level(level: log::LevelFilter) {
     *EXT_FILTER_LEVEL.write().unwrap() = level;
 }
 
@@ -56,13 +56,13 @@ pub fn set_ext_filter_level(level: log::LevelFilter) {
 pub fn set_filter_levels_from_env() {
     if let Ok(rust_log) = std::env::var("RUST_LOG") {
         if let Ok(filter_level) = log::LevelFilter::from_str(&rust_log) {
-            set_int_filter_level(filter_level);
-            set_ext_filter_level(filter_level);
+            set_internal_filter_level(filter_level);
+            set_external_filter_level(filter_level);
         }
     }
     if let Ok(cursive_log) = std::env::var("CURSIVE_LOG") {
         if let Ok(filter_level) = log::LevelFilter::from_str(&cursive_log) {
-            set_int_filter_level(filter_level);
+            set_internal_filter_level(filter_level);
         }
     }
 }

--- a/cursive-core/src/logger.rs
+++ b/cursive-core/src/logger.rs
@@ -37,7 +37,7 @@ lazy_static! {
     ///
     /// [`DebugView`]: ../views/struct.DebugView.html
     pub static ref LOGS: Mutex<VecDeque<Record>> =
-        Mutex::new(VecDeque::new());
+        Mutex::new(VecDeque::with_capacity(1_000));
 
     // Log filter level for log messages from within cursive
     static ref INT_FILTER_LEVEL: RwLock<log::LevelFilter> = RwLock::new(log::LevelFilter::Trace);
@@ -122,10 +122,6 @@ impl log::Log for CursiveLogger {
 /// Use a [`DebugView`](crate::views::DebugView) to see the logs, or use
 /// [`Cursive::toggle_debug_console()`](crate::Cursive::toggle_debug_console()).
 pub fn init() {
-    // ensure that the log queue capacity has been set
-    if LOGS.lock().unwrap().capacity() == 0 {
-        reserve_logs(1_000);
-    }
     log::set_max_level((*INT_FILTER_LEVEL.read().unwrap()).max(*EXT_FILTER_LEVEL.read().unwrap()));
     // This will panic if `set_logger` was already called.
     log::set_logger(&CursiveLogger).unwrap();
@@ -137,18 +133,12 @@ pub fn init() {
 ///
 /// An easier alternative might be to use [`init()`].
 pub fn get_logger() -> CursiveLogger {
-    // ensure that the log queue capacity has been set
-    if LOGS.lock().unwrap().capacity() == 0 {
-        reserve_logs(1_000);
-    }
     CursiveLogger
 }
 
 /// Adds `n` more entries to cursive's log queue.
 ///
 /// Most of the time you don't need to use this directly.
-///
-/// You should call this if you're not using `init()` nor `get_logger()`.
 pub fn reserve_logs(n: usize) {
     LOGS.lock().unwrap().reserve(n);
 }

--- a/cursive-core/src/logger.rs
+++ b/cursive-core/src/logger.rs
@@ -2,8 +2,8 @@
 
 use lazy_static::lazy_static;
 use std::collections::VecDeque;
-use std::sync::Mutex;
 use std::str::FromStr;
+use std::sync::Mutex;
 
 /// Saves all log records in a global deque.
 ///
@@ -45,7 +45,7 @@ pub struct CursiveLogger {
     // Log filter level for log messages from sources outside of cursive
     ext_filter_level: log::LevelFilter,
     // Size of log queue
-    log_size: usize
+    log_size: usize,
 }
 
 impl CursiveLogger {

--- a/cursive-core/src/logger.rs
+++ b/cursive-core/src/logger.rs
@@ -139,7 +139,7 @@ pub fn log(record: &log::Record) {
 
 impl log::Log for CursiveLogger {
     fn enabled(&self, metadata: &log::Metadata) -> bool {
-        if metadata.target().contains("cursive_core") {
+        if metadata.target().starts_with("cursive_core::") {
             metadata.level() <= self.int_filter_level
         } else {
             metadata.level() <= self.ext_filter_level

--- a/cursive-core/src/logger.rs
+++ b/cursive-core/src/logger.rs
@@ -39,19 +39,11 @@ impl CursiveLogger {
     /// If CURSIVE_LOG is set, then the internal log level is set to match
     /// Remember to call `init()` to install with `log` backend
     pub fn new() -> Self {
-        let mut logger = CursiveLogger {
+        CursiveLogger {
             int_filter_level: log::LevelFilter::Trace,
             ext_filter_level: log::LevelFilter::Trace,
             log_size: 1000,
-        };
-        if let Some(filter_level) = get_env_log_level("RUST_LOG") {
-            logger.int_filter_level = filter_level;
-            logger.ext_filter_level = filter_level;
         }
-        if let Some(filter_level) = get_env_log_level("CURSIVE_LOG") {
-            logger.int_filter_level = filter_level;
-        }
-        logger
     }
 
     /// sets the internal log filter level
@@ -63,6 +55,18 @@ impl CursiveLogger {
     /// sets the external log filter level
     pub fn with_ext_filter_level(mut self, level: log::LevelFilter) -> Self {
         self.ext_filter_level = level;
+        self
+    }
+
+    /// sets log filter levels based on environment variables `RUST_LOG` and `CURSIVE_LOG`
+    pub fn with_env(mut self) -> Self {
+        if let Some(filter_level) = get_env_log_level("RUST_LOG") {
+            self.int_filter_level = filter_level;
+            self.ext_filter_level = filter_level;
+        }
+        if let Some(filter_level) = get_env_log_level("CURSIVE_LOG") {
+            self.int_filter_level = filter_level;
+        }
         self
     }
 


### PR DESCRIPTION
Hello,

This is my attempt at following the first of my suggestions in #714 . 

I tried to leave as much alone as I could so that there would be no breaking changes with as many useful features as possible. Anyone using the logger now shouldn't have to change anything and get the exact same behavior. There shouldn't be any breaking changes to the existing API, either in function signatures or behavior.

Logging would use two different filter levels, one each for logs generated internally by cursive and externally by whatever else. This solves the issue in #714 as the debug messages won't clog the log with all the redraws from scrolling (assuming the filter levels are set appropriately). These levels are set either directly or by the environment variables `RUST_LOG` and `CURSIVE_LOG`. I also added the ability to change the log queue size too. I hope this meets option 2 in #467 as a "good enough" feature set.

Two small examples:
```
cursive::logger::CursiveLogger::new()
    .with_int_log_level(log::LevelFilter::Warn)
    .with_ext_log_level(log::LevelFilter::Debug)
    .with_log_size(10000)
    .init();
```

```
cursive::logger::CursiveLogger::new()
    .with_env()
    .with_log_size(10000)
    .init();
```

The whole `Box::leak(Box::new(self))` thing is to avoid having to add the `std` feature flag to `log` and change `Cargo.toml`. This is exactly how `log` handles `set_boxed_logger` internally.
