### PR TITLE
Fix missing import statement

### DIFF
--- a/doc/tutorial_1.md
+++ b/doc/tutorial_1.md
@@ -48,6 +48,8 @@ cursive = "*"
 Finally, update `src/main.rs` to import it:
 
 ```rust,no_run
+use cursive;
+
 fn main() {
 }
 ```


### PR DESCRIPTION
The tutorial was missing the import statement, this patch adds it.

<img width="441" alt="image" src="https://github.com/gyscos/cursive/assets/36491/fa5ac2be-e8b8-460b-a8ad-7074e69862b6">
