### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -373,7 +373,7 @@
 
 ### Breaking changes
 
-- Update `enum-map` fron 0.5 to 0.6
+- Update `enum-map` from 0.5 to 0.6
 
 ### API updates
 
@@ -392,7 +392,7 @@
 ### Bugfixes
 
 - Fix a possible panic when a TextView is updated asynchronously while it's
-  being layed out.
+  being laid out.
 - Fixed weird behaviour of `SizeConstraint::Full` with `ScrollView`.
 
 ## 0.12.0

--- a/cursive-core/src/cursive.rs
+++ b/cursive-core/src/cursive.rs
@@ -165,7 +165,7 @@ impl Cursive {
         self.user_data.downcast_mut()
     }
 
-    /// Attemps to take by value the current user-data.
+    /// Attempts to take by value the current user-data.
     ///
     /// If successful, this will replace the current user-data with the unit
     /// type `()`.
@@ -643,7 +643,7 @@ impl Cursive {
         self.root.set_on_event(trigger, crate::immut1!(cb));
     }
 
-    /// Registers a priotity callback.
+    /// Registers a priority callback.
     ///
     /// If an event matches the given trigger, it will not be sent to the view
     /// tree and will go to the given callback instead.

--- a/cursive-core/src/cursive_run.rs
+++ b/cursive-core/src/cursive_run.rs
@@ -184,9 +184,9 @@ where
     pub fn refresh(&mut self) {
         self.boring_frame_count = 0;
 
-        // Do we need to redraw everytime?
+        // Do we need to redraw every time?
         // Probably, actually.
-        // TODO: Do we need to re-layout everytime?
+        // TODO: Do we need to re-layout every time?
         self.layout();
 
         // TODO: Do we need to redraw every view every time?

--- a/cursive-core/src/direction.rs
+++ b/cursive-core/src/direction.rs
@@ -273,7 +273,7 @@ pub enum Absolute {
 
     /// No real direction.
     ///
-    /// Used when the "direction" is accross layers for instance.
+    /// Used when the "direction" is across layers for instance.
     None,
 }
 

--- a/cursive-core/src/printer.rs
+++ b/cursive-core/src/printer.rs
@@ -36,7 +36,7 @@ pub struct Printer<'a, 'b> {
     /// Size of the area we are allowed to draw on.
     ///
     /// Anything outside of this should be discarded.\
-    /// The view being drawn can ingore this, but anything further than that
+    /// The view being drawn can ignore this, but anything further than that
     /// will be ignored.
     pub output_size: Vec2,
 

--- a/cursive-core/src/rect.rs
+++ b/cursive-core/src/rect.rs
@@ -195,7 +195,7 @@ impl Rect {
         self.bottom_right.x
     }
 
-    /// Returns the Y value of the botton edge of the rectangle.
+    /// Returns the Y value of the bottom edge of the rectangle.
     ///
     /// This is inclusive.
     pub fn bottom(self) -> usize {

--- a/cursive-core/src/theme/color.rs
+++ b/cursive-core/src/theme/color.rs
@@ -209,7 +209,7 @@ impl FromStr for Color {
     }
 }
 
-/// Parses a hex represenation of a color.
+/// Parses a hex representation of a color.
 ///
 /// Optionally prefixed with `#` or `0x`.
 fn parse_hex_color(value: &str) -> Option<Color> {

--- a/cursive-core/src/theme/mod.rs
+++ b/cursive-core/src/theme/mod.rs
@@ -141,7 +141,7 @@
 //! ```
 //!
 //! To use the theme in your application, load it with [`Cursive::load_toml`]
-//! method (or use [`theme::load_theme_file`] to aquire the theme object).
+//! method (or use [`theme::load_theme_file`] to acquire the theme object).
 //!
 //! ```rust,ignore
 //! let mut siv = Cursive::new();
@@ -292,12 +292,12 @@ impl Theme {
 /// Possible error returned when loading a theme.
 #[derive(Debug)]
 pub enum Error {
-    /// An error occured when reading the file.
+    /// An error occurred when reading the file.
     Io(io::Error),
 
     #[cfg(feature = "toml")]
     #[cfg_attr(feature = "doc-cfg", doc(cfg(feature = "toml")))]
-    /// An error occured when parsing the toml content.
+    /// An error occurred when parsing the toml content.
     Parse(toml::de::Error),
 }
 

--- a/cursive-core/src/utils/immutify.rs
+++ b/cursive-core/src/utils/immutify.rs
@@ -10,7 +10,7 @@
 
 /// Wraps a `FnMut` into a `Fn`
 ///
-/// This can be used to use a `FnMut` when a callack expects a `Fn`.
+/// This can be used to use a `FnMut` when a callback expects a `Fn`.
 ///
 /// # Note
 ///

--- a/cursive-core/src/utils/lines/spans/chunk.rs
+++ b/cursive-core/src/utils/lines/spans/chunk.rs
@@ -37,7 +37,7 @@ impl Chunk {
                 self.width -= to_remove.width;
                 break;
             } else {
-                // This segment is too small, so it'll disapear entirely.
+                // This segment is too small, so it'll disappear entirely.
                 to_remove.length -= segment.end - segment.start;
                 to_remove.width -= segment.width;
                 self.width -= segment.width;

--- a/cursive-core/src/utils/lines/spans/chunk_iterator.rs
+++ b/cursive-core/src/utils/lines/spans/chunk_iterator.rs
@@ -8,7 +8,7 @@ use xi_unicode::LineBreakLeafIter;
 
 /// Iterator that returns non-breakable chunks of text.
 ///
-/// Works accross spans of text.
+/// Works across spans of text.
 pub struct ChunkIterator<S> {
     /// Input that we want to chunk.
     source: Rc<S>,
@@ -33,7 +33,7 @@ impl<S> ChunkIterator<S> {
 
 /// This iterator produces chunks of non-breakable text.
 ///
-/// These chunks may go accross spans (a single word may be broken into more
+/// These chunks may go across spans (a single word may be broken into more
 /// than one span, for instance if parts of it are marked up differently).
 impl<S> Iterator for ChunkIterator<S>
 where

--- a/cursive-core/src/utils/lines/spans/lines_iterator.rs
+++ b/cursive-core/src/utils/lines/spans/lines_iterator.rs
@@ -10,7 +10,7 @@ use std::rc::Rc;
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
-/// Generates rows of text in constrainted width.
+/// Generates rows of text in constrained width.
 ///
 /// Works on spans of text.
 pub struct LinesIterator<S>

--- a/cursive-core/src/utils/span.rs
+++ b/cursive-core/src/utils/span.rs
@@ -189,7 +189,7 @@ impl<T> SpannedString<T> {
         let source = source.into();
 
         // Make sure the spans are within bounds.
-        // This should disapear when compiled in release mode.
+        // This should disappear when compiled in release mode.
         for span in &spans {
             if let IndexedCow::Borrowed { end, .. } = span.content {
                 assert!(end <= source.len());

--- a/cursive-core/src/view/mod.rs
+++ b/cursive-core/src/view/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! Views are the main building blocks of your UI.
 //!
-//! A view can delegate part or all of its responsabilities to child views,
+//! A view can delegate part or all of its responsibilities to child views,
 //! forming a view tree. The root of this tree is a `StackView` handled
 //! directly by the `Cursive` element.
 //!

--- a/cursive-core/src/view/position.rs
+++ b/cursive-core/src/view/position.rs
@@ -61,7 +61,7 @@ pub enum Offset {
 }
 
 impl Offset {
-    /// Computes a single-dimension offset requred to draw a view.
+    /// Computes a single-dimension offset required to draw a view.
     pub fn compute_offset(&self, size: usize, available: usize, parent: usize) -> usize {
         if size > available {
             0

--- a/cursive-core/src/view/scroll/core.rs
+++ b/cursive-core/src/view/scroll/core.rs
@@ -317,14 +317,14 @@ impl Core {
         self.enabled
     }
 
-    /// Control whether scroll bars are visibile.
+    /// Control whether scroll bars are visible.
     ///
     /// Defaults to `true`.
     pub fn set_show_scrollbars(&mut self, show_scrollbars: bool) {
         self.show_scrollbars = show_scrollbars;
     }
 
-    /// Control whether scroll bars are visibile.
+    /// Control whether scroll bars are visible.
     ///
     /// Chainable variant
     #[must_use]

--- a/cursive-core/src/view/scroll_base.rs
+++ b/cursive-core/src/view/scroll_base.rs
@@ -76,7 +76,7 @@ impl ScrollBase {
         self
     }
 
-    /// Call this method whem the content or the view changes.
+    /// Call this method when the content or the view changes.
     pub fn set_heights(&mut self, view_height: usize, content_height: usize) {
         self.view_height = view_height;
         self.content_height = content_height;

--- a/cursive-core/src/view/view_trait.rs
+++ b/cursive-core/src/view/view_trait.rs
@@ -43,7 +43,7 @@ pub trait View: Any + AnyView {
     ///
     /// View groups should propagate the information to their children.
     ///
-    /// At this point, the given size is final and cannot be negociated.
+    /// At this point, the given size is final and cannot be negotiated.
     /// It is guaranteed to be the size available for the call to `draw()`.
     fn layout(&mut self, _: Vec2) {}
 

--- a/cursive-core/src/views/fixed_layout.rs
+++ b/cursive-core/src/views/fixed_layout.rs
@@ -78,7 +78,7 @@ impl FixedLayout {
         self.focus
     }
 
-    /// Attemps to set the focus on the given child.
+    /// Attempts to set the focus on the given child.
     ///
     /// Returns `Err(())` if `index >= self.len()`, or if the view at the
     /// given index does not accept focus.

--- a/cursive-core/src/views/linear_layout.rs
+++ b/cursive-core/src/views/linear_layout.rs
@@ -213,7 +213,7 @@ impl LinearLayout {
         self.focus
     }
 
-    /// Attemps to set the focus on the given child.
+    /// Attempts to set the focus on the given child.
     ///
     /// Returns `Err(ViewNotFound)` if `index >= self.len()`, or if the view at the
     /// given index does not accept focus.

--- a/cursive-core/src/views/menu_popup.rs
+++ b/cursive-core/src/views/menu_popup.rs
@@ -210,7 +210,7 @@ impl MenuPopup {
                 OnEventView::new(MenuPopup::new(Rc::clone(&tree)).on_action(move |s| {
                     // This will happen when the subtree popup
                     // activates something;
-                    // First, remove ourselve.
+                    // First, remove ourself.
                     s.pop_layer();
                     if let Some(ref action_cb) = action_cb {
                         action_cb.clone()(s);

--- a/cursive-core/src/views/scroll_view.rs
+++ b/cursive-core/src/views/scroll_view.rs
@@ -99,14 +99,14 @@ impl<V> ScrollView<V> {
         })
     }
 
-    /// Control whether scroll bars are visibile.
+    /// Control whether scroll bars are visible.
     ///
     /// Defaults to `true`.
     pub fn set_show_scrollbars(&mut self, show_scrollbars: bool) {
         self.core.set_show_scrollbars(show_scrollbars);
     }
 
-    /// Control whether scroll bars are visibile.
+    /// Control whether scroll bars are visible.
     ///
     /// Chainable variant
     #[must_use]

--- a/cursive-core/src/views/select_view.rs
+++ b/cursive-core/src/views/select_view.rs
@@ -755,7 +755,7 @@ impl<T: 'static> SelectView<T> {
     }
 
     fn open_popup(&mut self) -> EventResult {
-        // Build a shallow menu tree to mimick the items array.
+        // Build a shallow menu tree to mimic the items array.
         // TODO: cache it?
         let mut tree = menu::Tree::new();
         for (i, item) in self.items.iter().enumerate() {

--- a/cursive-core/src/views/stack_view.rs
+++ b/cursive-core/src/views/stack_view.rs
@@ -636,7 +636,7 @@ impl StackView {
 
     /// Background drawing
     ///
-    /// Drawing functions are split into forground and background to
+    /// Drawing functions are split into foreground and background to
     /// ease inserting layers under the stackview but above its background.
     ///
     /// You probably just want to call draw()
@@ -656,7 +656,7 @@ impl StackView {
 
     /// Foreground drawing
     ///
-    /// Drawing functions are split into forground and background to
+    /// Drawing functions are split into foreground and background to
     /// ease inserting layers under the stackview but above its background.
     ///
     /// you probably just want to call draw()
@@ -724,7 +724,7 @@ where
 impl View for StackView {
     fn draw(&self, printer: &Printer) {
         // This function is included for compat with the view trait,
-        // it should behave the same as calling them seperately, but does
+        // it should behave the same as calling them separately, but does
         // not pause to let you insert in between the layers.
         self.draw_bg(printer);
         self.draw_fg(printer);
@@ -825,7 +825,7 @@ mod tests {
         // Start with a simple stack
         let mut stack = StackView::new().layer(TextView::new("1"));
 
-        // And keep poping and re-pushing the view
+        // And keep popping and re-pushing the view
         for _ in 0..20 {
             let layer = stack.pop_layer().unwrap();
             stack.add_layer(layer);

--- a/cursive-core/src/views/text_area.rs
+++ b/cursive-core/src/views/text_area.rs
@@ -392,7 +392,7 @@ impl TextArea {
 
     /// Fix a damage located at the cursor.
     ///
-    /// The only damages are assumed to have occured around the cursor.
+    /// The only damages are assumed to have occurred around the cursor.
     ///
     /// This is an optimization to not re-compute the entire rows when an
     /// insert happened.

--- a/cursive-core/src/views/text_view.rs
+++ b/cursive-core/src/views/text_view.rs
@@ -133,7 +133,7 @@ impl TextContent {
     }
 }
 
-/// Internel representation of the content for a `TextView`.
+/// Internal representation of the content for a `TextView`.
 ///
 /// This is mostly just a `StyledString`.
 ///

--- a/cursive/examples/Readme.md
+++ b/cursive/examples/Readme.md
@@ -89,7 +89,7 @@ This example draws a colorful square to show off true color support.
 
 ## [`refcell_view`](./refcell_view.rs)
 
-Here we show how to access multiple views concurently through their name.
+Here we show how to access multiple views concurrently through their name.
 
 ## [`progress`](./progress.rs)
 

--- a/cursive/examples/position.rs
+++ b/cursive/examples/position.rs
@@ -10,7 +10,7 @@ fn move_top(c: &mut Cursive, x_in: isize, y_in: isize) {
     let s = c.screen_mut();
     let l = LayerPosition::FromFront(0);
 
-    // Step 2. add the specifed amount
+    // Step 2. add the specified amount
     let pos = s
         .layer_offset(LayerPosition::FromFront(0))
         .unwrap()

--- a/cursive/examples/radio.rs
+++ b/cursive/examples/radio.rs
@@ -36,7 +36,7 @@ fn main() {
                         LinearLayout::vertical()
                             // For the size, we store a number separately
                             .child(size_group.button(5, "Small"))
-                            // The initial selection can also be overriden
+                            // The initial selection can also be overridden
                             .child(size_group.button(15, "Medium").selected())
                             // The large size is out of stock, sorry!
                             .child(size_group.button(25, "Large").disabled()),

--- a/cursive/src/backends/curses/n.rs
+++ b/cursive/src/backends/curses/n.rs
@@ -527,7 +527,7 @@ fn initialize_keymap() -> HashMap<i32, Event> {
     for c in 1..=26 {
         let event = match c {
             // Ctrl-i and Ctrl-j are special, they use the same codes as Tab
-            // and Enter respecively. There's just no way to detect them. :(
+            // and Enter respectively. There's just no way to detect them. :(
             9 => Event::Key(Key::Tab),
             10 => Event::Key(Key::Enter),
             other => Event::CtrlChar((b'a' - 1 + other as u8) as char),

--- a/cursive/src/backends/mod.rs
+++ b/cursive/src/backends/mod.rs
@@ -5,7 +5,7 @@
 //!
 //! This module defines the [`Backend`] trait, as well as a few implementations
 //! using some common libraries. Each of those included backends needs a
-//! corresonding feature to be enabled.
+//! corresponding feature to be enabled.
 //!
 //! [`Backend`]: ../backend/trait.Backend.html
 #[cfg(unix)]

--- a/cursive/src/backends/puppet/mod.rs
+++ b/cursive/src/backends/puppet/mod.rs
@@ -62,7 +62,7 @@ impl Backend {
         self.current_style.borrow().clone()
     }
 
-    /// Ouput stream of consecutive frames rendered by Puppet backend
+    /// Output stream of consecutive frames rendered by Puppet backend
     pub fn stream(&self) -> Receiver<ObservedScreen> {
         self.screen_channel.1.clone()
     }

--- a/cursive/src/backends/puppet/observed.rs
+++ b/cursive/src/backends/puppet/observed.rs
@@ -179,7 +179,7 @@ impl ObservedScreen {
         println!("{self}")
     }
 
-    /// Returns occurences of given string pattern
+    /// Returns occurrences of given string pattern
     pub fn find_occurences(&self, pattern: &str) -> Vec<ObservedLine> {
         // TODO(njskalski): test for two-cell letters.
         // TODO(njskalski): fails with whitespaces like "\t".


### PR DESCRIPTION
Found via `codespell -S lorem.txt -L crate,resizeable,shrinked,atleast,axises,noo`