### PR TITLE
Handle Ctrl-Key events in EditView & some general, small improvements

### DIFF
--- a/cursive-core/src/views/edit_view.rs
+++ b/cursive-core/src/views/edit_view.rs
@@ -381,6 +381,11 @@ impl EditView {
         self
     }
 
+    /// Returns the currest cursor position.
+    pub fn get_cursor(&self) -> usize {
+        self.cursor
+    }
+
     /// Sets the cursor position.
     pub fn set_cursor(&mut self, cursor: usize) {
         self.cursor = cursor;

--- a/cursive-core/src/views/edit_view.rs
+++ b/cursive-core/src/views/edit_view.rs
@@ -430,7 +430,7 @@ impl EditView {
     /// You should run this callback with a `&mut Cursive`.
     pub fn remove(&mut self, len: usize) -> Callback {
         let start = self.cursor;
-        let end = self.cursor + len;
+        let end = self.cursor + len.min(self.content.len() - self.cursor);
         for _ in Rc::make_mut(&mut self.content).drain(start..end) {}
 
         self.keep_cursor_in_view();

--- a/cursive-core/src/views/edit_view.rs
+++ b/cursive-core/src/views/edit_view.rs
@@ -766,3 +766,36 @@ crate::var_recipe!("EditView.with_content", |config, context| {
 
     Ok(result)
 });
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ctrl_key_events() {
+        let mut view = EditView::new().content("foobarbaz");
+        view.set_cursor(0);
+
+        view.on_event(Event::CtrlChar('f'));
+        assert_eq!(view.get_cursor(), 1);
+
+        view.on_event(Event::CtrlChar('b'));
+        assert_eq!(view.get_cursor(), 0);
+
+        view.on_event(Event::CtrlChar('e'));
+        assert_eq!(view.get_cursor(), view.get_content().len());
+
+        view.on_event(Event::CtrlChar('a'));
+        assert_eq!(view.get_cursor(), 0);
+
+        view.set_cursor(3);
+        view.on_event(Event::CtrlChar('u'));
+        assert_eq!(view.get_cursor(), 0);
+        assert_eq!(*view.get_content(), "barbaz");
+
+        view.set_cursor(3);
+        view.on_event(Event::CtrlChar('k'));
+        assert_eq!(view.get_cursor(), 3);
+        assert_eq!(*view.get_content(), "bar");
+    }
+}


### PR DESCRIPTION
Hi!

First of, thank you for `cursive`!
A rather important thing that popped up while implementing the new [TUI-based installer](https://git.proxmox.com/?p=pve-installer.git;a=tree;f=proxmox-tui-installer;hb=HEAD) for Proxmox was that the `EditView` does not handle `^U`, `^K` etc.

This implements that, plus some tests on top as well.
Also included is the addition of a `.get_cursor()` method, as well as the clamping of the length in `.remove()`, two things that would be quite useful to have.

Thanks in advance!