### PR TITLE
Add missing Shift-Tab key event in Termion backend

### DIFF
--- a/cursive/src/backends/termion.rs
+++ b/cursive/src/backends/termion.rs
@@ -179,6 +179,7 @@ impl Backend {
             TEvent::Key(TKey::F(j)) => Event::Unknown(vec![j]),
             TEvent::Key(TKey::Char('\n')) => Event::Key(Key::Enter),
             TEvent::Key(TKey::Char('\t')) => Event::Key(Key::Tab),
+            TEvent::Key(TKey::BackTab) => Event::Shift(Key::Tab),
             TEvent::Key(TKey::Char(c)) => Event::Char(c),
             TEvent::Key(TKey::Ctrl(c)) => Event::CtrlChar(c),
             TEvent::Key(TKey::Alt(c)) => Event::AltChar(c),


### PR DESCRIPTION
This fixes Shift-Tab detection (and thus circular focus view etc.) when using the Termion backend.

Greets!