### PR TITLE
Add method to return character from char event.

### DIFF
--- a/cursive-core/src/event.rs
+++ b/cursive-core/src/event.rs
@@ -533,6 +533,15 @@ pub enum Event {
 }
 
 impl Event {
+    /// Returns the character, if `self` is a char event.
+    pub fn char(&self) -> Option<char> {
+        if let Event::Char(c) = *self {
+            Some(c)
+        } else {
+            None
+        }
+    }
+    
     /// Returns the position of the mouse, if `self` is a mouse event.
     pub fn mouse_position(&self) -> Option<Vec2> {
         if let Event::Mouse { position, .. } = *self {
@@ -542,7 +551,7 @@ impl Event {
         }
     }
 
-    /// Returns a mutable reference to the position of the mouse/
+    /// Returns a mutable reference to the position of the mouse.
     ///
     /// Returns `None` if `self` is not a mouse event.
     pub fn mouse_position_mut(&mut self) -> Option<&mut Vec2> {

--- a/cursive-core/src/event.rs
+++ b/cursive-core/src/event.rs
@@ -535,13 +535,14 @@ pub enum Event {
 impl Event {
     /// Returns the character, if `self` is a char event.
     pub fn char(&self) -> Option<char> {
-        if let Event::Char(c) = *self {
-            Some(c)
-        } else {
-            None
+        match *self {
+            Event::Char(c) => Some(c),
+            Event::AltChar(c) => Some(c),
+            Event::CtrlChar(c) => Some(c),
+            _ => None,
         }
     }
-    
+
     /// Returns the position of the mouse, if `self` is a mouse event.
     pub fn mouse_position(&self) -> Option<Vec2> {
         if let Event::Mouse { position, .. } = *self {


### PR DESCRIPTION
Firstly, thank you for this library. I've really enjoyed hacking my way through it.

This is a minor proposal that helped me clean up some ugly code. Here's an example:

``` Rust
use cursive::event::{Event, EventResult, EventTrigger};
use cursive::views::TextView;

fn main() {
    let mut siv = cursive::default();
    siv.add_layer(TextView::new("enter uppercased character:"));

    siv.set_on_pre_event_inner(uppercased(), move |event| {
        // use the method here
        let c = event.char().expect("only chars are triggered");
        Some(EventResult::with_cb(move |siv| {
            siv.add_layer(TextView::new(format!("do something useful with: {}", c)))
        }))
    });

    siv.set_on_pre_event(Event::Char('q'), |siv| siv.quit());
    siv.run();
}

fn uppercased() -> EventTrigger {
    EventTrigger::from_fn(|e| matches!(e, Event::Char('A'..='Z')))
}
```

This `Event::chars()` method allows us to access the inputted character without creating a mapping, which is a bit tedious when you want to capture a range of values (as we do in the example).