### PR TITLE
change workspace resolver to "2"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,4 @@
 [workspace]
 
 members = ["cursive", "cursive-core", "cursive-syntect", "cursive-macros"]
+resolver = "2"


### PR DESCRIPTION
This PR changes the resolver for the workspace to be version `2`, because all lower crates use edition `2021` which default to resolver `2`, as per cargo warning:

```txt
warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest

```