### PR TITLE
Add ability to replace an item in a select view

### DIFF
--- a/cursive-core/src/views/select_view.rs
+++ b/cursive-core/src/views/select_view.rs
@@ -424,6 +424,15 @@ impl<T: 'static> SelectView<T> {
             .unwrap_or_else(Callback::dummy)
     }
 
+    /// Replaces an item in the list.
+    pub fn replace_item<S>(&mut self, id: usize, label: S, value: T)
+    where
+        S: Into<StyledString>,
+    {
+        self.items[id] = Item::new(label.into(), value);
+        self.last_required_size = None;
+    }
+
     /// Inserts an item at position `index`, shifting all elements after it to
     /// the right.
     pub fn insert_item<S>(&mut self, index: usize, label: S, value: T)


### PR DESCRIPTION
This is a more efficient way to replace an item than calling `remove_item`, then `insert_item`