### PR TITLE
make `cursive` work with `ncurses` v6.0.1

### DIFF
--- a/cursive/Cargo.toml
+++ b/cursive/Cargo.toml
@@ -34,7 +34,7 @@ version = "2"
 [dependencies.ncurses]
 features = ["wide"]
 optional = true
-version = "5.99.0"
+version = "6.0.1"
 
 [dependencies.pancurses]
 features = ["wide"]

--- a/cursive/src/backends/curses/n.rs
+++ b/cursive/src/backends/curses/n.rs
@@ -357,28 +357,28 @@ impl backend::Backend for Backend {
 
     fn set_effect(&self, effect: Effect) {
         let style = match effect {
-            Effect::Reverse => ncurses::A_REVERSE(),
-            Effect::Simple => ncurses::A_NORMAL(),
-            Effect::Dim => ncurses::A_DIM(),
-            Effect::Bold => ncurses::A_BOLD(),
-            Effect::Blink => ncurses::A_BLINK(),
-            Effect::Italic => ncurses::A_ITALIC(),
-            Effect::Strikethrough => ncurses::A_NORMAL(),
-            Effect::Underline => ncurses::A_UNDERLINE(),
+            Effect::Reverse => ncurses::A_REVERSE,
+            Effect::Simple => ncurses::A_NORMAL,
+            Effect::Dim => ncurses::A_DIM,
+            Effect::Bold => ncurses::A_BOLD,
+            Effect::Blink => ncurses::A_BLINK,
+            Effect::Italic => ncurses::A_ITALIC,
+            Effect::Strikethrough => ncurses::A_NORMAL,
+            Effect::Underline => ncurses::A_UNDERLINE,
         };
         ncurses::attron(style);
     }
 
     fn unset_effect(&self, effect: Effect) {
         let style = match effect {
-            Effect::Reverse => ncurses::A_REVERSE(),
-            Effect::Simple => ncurses::A_NORMAL(),
-            Effect::Dim => ncurses::A_DIM(),
-            Effect::Bold => ncurses::A_BOLD(),
-            Effect::Blink => ncurses::A_BLINK(),
-            Effect::Italic => ncurses::A_ITALIC(),
-            Effect::Strikethrough => ncurses::A_NORMAL(),
-            Effect::Underline => ncurses::A_UNDERLINE(),
+            Effect::Reverse => ncurses::A_REVERSE,
+            Effect::Simple => ncurses::A_NORMAL,
+            Effect::Dim => ncurses::A_DIM,
+            Effect::Bold => ncurses::A_BOLD,
+            Effect::Blink => ncurses::A_BLINK,
+            Effect::Italic => ncurses::A_ITALIC,
+            Effect::Strikethrough => ncurses::A_NORMAL,
+            Effect::Underline => ncurses::A_UNDERLINE,
         };
         ncurses::attroff(style);
     }
@@ -533,7 +533,7 @@ fn initialize_keymap() -> HashMap<i32, Event> {
     }
 
     // Ncurses provides a F1 variable, but no modifiers
-    add_fn(ncurses::KEY_F1, Event::Key, &mut map);
+    add_fn(ncurses::KEY_F(1), Event::Key, &mut map);
     add_fn(277, Event::Shift, &mut map);
     add_fn(289, Event::Ctrl, &mut map);
     add_fn(301, Event::CtrlShift, &mut map);

--- a/cursive/src/backends/curses/n.rs
+++ b/cursive/src/backends/curses/n.rs
@@ -110,7 +110,10 @@ impl Backend {
             let path = CString::new(output_path).unwrap();
             unsafe { libc::fopen(path.as_ptr(), mode.as_ptr()) }
         };
-        ncurses::newterm(None, output, input);
+        ncurses::newterm(None, output, input).map_err(|e| {
+            io::Error::new(io::ErrorKind::Other, format!("could not call newterm: {e}"))
+        })?;
+
         // Enable keypad (like arrows)
         ncurses::keypad(ncurses::stdscr(), true);
 

--- a/cursive/src/backends/curses/n.rs
+++ b/cursive/src/backends/curses/n.rs
@@ -405,7 +405,9 @@ impl backend::Backend for Backend {
     }
 
     fn print(&self, text: &str) {
-        ncurses::addstr(text);
+        // &str is assured it doesn't contain any \0 aka nuls here due to PR 786
+        // thus we can ignore the return value and avoid warning: unused `Result` that must be used
+        let _ = ncurses::addstr(text);
     }
 }
 


### PR DESCRIPTION
<del>but first: `ncurses-rs` needs the changes in this PR: https://github.com/jeaye/ncurses-rs/pull/220  (or ideally the ones in this PR https://github.com/jeaye/ncurses-rs/pull/218 , depending on which PR gets merged I'll (re)test the below)</del>

`ncurses` crate v 6.0.1 is published and enough.

However `pancurses` doesn't need [these](https://github.com/ihalila/pancurses/pull/93) changes looks like, for `cursive` to work with it, so `0.17` seems good (but `cursive`'s examples are not tested with `0.17`).

The following were used successfully:
* `cargo build`
* `cargo test`
* `cargo build --all-features`
* `cargo test --all-features`
* `cargo build --all-targets`
* `cargo test --all-targets`
* `cargo build --all-targets --all-features`
* `cargo test --all-targets --all-features`
* `cargo build --features="ncurses-backend"`
* `cargo test --features="ncurses-backend"`
* `cargo build --features="ncurses-backend" --all-targets`
* `cargo test --features="ncurses-backend" --all-targets`

... on each of these target environments:

Legend:
- ❌ = known not to work
- [ ] = untested
- [x] = works

- [x] Gentoo 2.15 default/linux/amd64/23.0/split-usr/no-multilib (stable) <del>-won't build but it would've if https://github.com/jeaye/ncurses-rs/pull/218 was merged.</del>
  - [ ] some examples tested
  - [ ] all examples tested
- [ ] NixOS (if `PKG_CONFIG_PATH` is set to the dir containing `ncurses.pc` file, or used `nix-shell` command in `cursive` repo dir)
  - [ ] some examples tested
  - [ ] all examples tested
- [ ] Fedora 39
  - [ ] some examples tested
  - [ ] all examples tested
- [ ] Ubuntu Desktop 22.04.4 LTS (needs `libncurses-dev`)
  - [ ] tested to work without `pkg-config` and `pkgconf` installed.
  - [ ] tested to work with `pkg-config` installed.
- [ ] FreeBSD 14.0-RELEASE
  - [ ] some examples tested
  - [ ] all examples tested
- [ ] OpenBSD 7.5 GENERIC
  - [ ] needs one of `LC_CTYPE=en_US.UTF-8` or `LANG=en_US.UTF-8` to be set otherwise it looks as if it doesn't have wide chars support so `cursive` and `pancuses` examples look pretty broken.
- [ ] MacOS Mojave v10.14.6 (with [this](https://github.com/gyscos/cursive/wiki/Install-ncurses#macos))
  - [ ] some examples tested
  - [ ] all examples tested
- [ ] Windows 11 WSL1 [Arch Linux](https://github.com/yuk7/ArchWSL) Linux DESKTOP 4.4.0-22621-Microsoft #2506-Microsoft Fri Jan 01 08:00:00 PST 2016 x86_64 GNU/Linux
  - [ ] some examples tested
  - [ ] all examples tested



TODO:
- [x] compiles(and passes `cargo test`) with `pancurses` (dep) `0.17` but this means it uses `v5.101.0` of `ncurses` crate for `pancurses` and v 6.0.1 for `cursive`, see `cargo tree --all-features | less` (search for `ncurses`)
- [x] compiles(and passes `cargo test`) with `pancurses` `main` branch from github with [this](https://github.com/ihalila/pancurses/pull/93) PR in.
- [ ] does `cursive` need version bump in this PR? ie. `version = "0.21.0"` or shall this be left to be done by the repo owner ?!
- [x] use exact `ncurses-rs` version in `Cargo.toml` after it gets published, ie. so it's not lower than that version, because then it would break compilation of `cursive`. Note that `pancurses` doesn't need a version bump (see above), although the examples I'm running are through the PR-ed `pancurses` only.
- [ ] maybe bump `pancurses` in `Cargo.toml` too, after it gets [its PR](https://github.com/ihalila/pancurses/pull/93) for the v6 `ncurses-rs` usage.
- [x] add `cargo test --example select_test -- --nocapture` in addition to the suggested `--bin` which doesn't work.
- [ ] fix all warnings (because they were introduced by this PR / the upgrade to `ncurses-rs` v6)
  - [ ] `warning: attribute should be applied to a foreign function or static` `#[link_name="box"]` `not a foreign function or static`, [this is on `ncurses-rs`](https://github.com/jeaye/ncurses-rs/pull/218#issuecomment-2049572573)
  - [x] `warning: unused `Result` that must be used`, (for all 3 cases) happens due to [`CString::new`](https://doc.rust-lang.org/std/ffi/struct.CString.html#method.new) `This function will return an error if the supplied bytes contain an internal 0 byte.`
    - [x] `ncurses::newterm` `.unwrap()` is safe here due to using `None` as the first arg to [`newterm`](https://github.com/jeaye/ncurses-rs/blob/3aa22bc279e4929e3ab69d49f75a18eda3e431e9/src/lib.rs#L1023-L1029)
    - [x] `ncurses::addstr`
      - [x] `\0` is already handled by `cursive` (due to PR #786 and followups) so it won't reach the `addstr` call, <del>unless in the future a dep gets updated to include this https://github.com/unicode-rs/unicode-width/commit/4efb1803faa054f1bea3c0457275ad3c8610170b#diff-2ad10836ccce5ac2056d5679cc92449d9ff9094d4ff5c5803f65b5dd1d52ef19R224 </del> this is handled too now.
- [ ] run `cargo clippy` and fix:
  - [x] errors (there were none)
  - [ ] warnings
    - [ ] pre this PR warnings
      - [ ] via `cargo clippy --all-targets`
      - [ ] via `cargo clippy --all-targets --all-features`
- [x] passes `cargo test --features="ncurses-backend,ansi,toml"`
- [x] get rid of old irrelevant commits that this PR introduced, since they're now mostly obsolete due to new `cursive` commits.
- [x] I'm watching(github notifications All Activity) the entire repo for any future-reported breakage, to address it.
- [ ] test that examples compile and run seemingly ok(for  on which OS/distro see above) via `cargo run --features="ncurses-backend" --example NAME`:
  - [x] advanced_user_data
  - [x] ansi via `cargo run --features="ncurses-backend,ansi" --example ansi`
  - [x] autocomplete
  - [x] builder via `cargo run --features="ncurses-backend,builder" --example builder` (but looks better with `crossterm-backend` which is now the default I [noticed](https://github.com/gyscos/cursive/commit/7c676b29f47b6c4e79f8d67ef5509c047f08edd4))
  - [x] colors
  - [x] ctrl_c
  - [x] debug_console
  - [x] dialog
  - [x] edit
  - [x] fixed_layout
  - [x] focus
  - [x] hello_world
  - [x] key_codes
  - [x] linear
  - [x] list_view
  - [x] logs (note: the default aka `crossterm-backend` has no flickering on bottom line which is great)
  - [x] lorem
  - [x] markup
  - [x] menubar
  - [ ] mines
  - [ ] mutation
  - [ ] panels
  - [x] parse
  - [ ] pause
  - [ ] position
  - [ ] progress
  - [ ] radio
  - [ ] refcell_view
  - [ ] scroll
  - [ ] select
  - [x] `select_test` via `cargo test --features="ncurses-backend" --example select_test -- --nocapture`
  - [ ] slider
  - [ ] status
  - [ ] status_bar_ext
  - [ ] stopwatch
  - [ ] tcp_server
  - [ ] terminal_default
  - [ ] text_area
  - [ ] theme
  - [ ] theme_editor
  - [ ] theme_manual
  - [x] themed_view
  - [x] user_data
  - [x] vpv
  - [x] window_title
- [ ] test each of those in [showcases](https://github.com/gyscos/cursive?tab=readme-ov-file#showcases):
  - [ ] [RustyChat](https://github.com/SambaDialloB/RustyChat): Chat client made using Rust and Cursive.
  - [ ] [checkline](https://github.com/sixarm/checkline-rust-crate): Checkbox line picker from stdin to stdout.
  - [ ] [clock-cli](https://github.com/TianyiShi2001/clock-cli-rs): A clock with stopwatch and countdown timer functionalities.
  - [ ] [fui](https://github.com/xliiv/fui): Add CLI & form interface to your program.
  - [ ] [game2048-rs](https://github.com/genieCS/game2048-rs): a tui game2048 using Rust and cursive.
  - [ ] [git-branchless](https://github.com/arxanas/git-branchless): Branchless workflow for Git.
  - [ ] [grin-tui](https://github.com/mimblewimble/grin): Minimal implementation of the MimbleWimble protocol.
  - [ ] [kakikun](https://github.com/file-acomplaint/kakikun): A paint and ASCII art application for the terminal.
  - [ ] [launchk](https://github.com/mach-kernel/launchk): Manage launchd agents and daemons on macOS.
  - [ ] [mythra](https://github.com/deven96/mythra): CLI to search for music.
  - [ ] [ncspot](https://github.com/hrkfdn/ncspot): Cross-platform ncurses Spotify client.
  - [ ] [rbmenu-tui](https://github.com/DevHyperCoder/rbmenu-tui): A TUI for bookmark management.
  - [ ] [retris](https://github.com/genieCS/retris): A simple implementation of the classic tetris game.
  - [ ] [ripasso](https://github.com/cortex/ripasso): A simple password manager written in Rust.
  - [ ] [rusty-man](https://sr.ht/~ireas/rusty-man): Browse rustdoc documentation.
  - [ ] [saci-rs](https://gitlab.com/ihercowitz/saci-rs): Simple API Client Interface.
  - [ ] [so](https://github.com/samtay/so): A terminal interface for Stack Overflow.
  - [ ] [sudoku-tui](https://github.com/TianyiShi2001/sudoku-tui): Play sudoku on the command line.
  - [ ] [tap](https://github.com/timdubbins/tap): An audio player for the terminal with fuzzy finder.
  - [ ] [ttyloop](https://github.com/gamma-delta/ttyloop): Clone of the mobile game Loop.
  - [ ] [wiki-tui](https://github.com/Builditluc/wiki-tui): A simple and easy to use Wikipedia Text User Interface

