### PR TITLE
Speed up `PrintBuffer::flush()`

### DIFF
--- a/cursive-core/src/buffer.rs
+++ b/cursive-core/src/buffer.rs
@@ -420,9 +420,14 @@ impl PrintBuffer {
     ///
     /// (Successive calls should do nothing.)
     pub fn flush(&mut self, backend: &dyn Backend) {
-        let terminal_width = self.size.x;
+        match backend.is_persistent() {
+            true => self.flush_to_backend::<true>(backend),
+            false => self.flush_to_backend::<false>(backend),
+        }
+    }
 
-        let persistent = backend.is_persistent();
+    fn flush_to_backend<const IS_PERSISTENT: bool>(&mut self, backend: &dyn Backend) {
+        let terminal_width = self.size.x;
 
         let mut current_pos = Vec2::zero();
         backend.move_to(current_pos);
@@ -430,10 +435,10 @@ impl PrintBuffer {
         for (i, (active, frozen)) in self
             .active_buffer
             .iter()
-            .zip(self.frozen_buffer.iter())
+            .zip(self.frozen_buffer.iter_mut())
             .enumerate()
         {
-            if persistent && active == frozen {
+            if IS_PERSISTENT && active == frozen {
                 // TODO (optim): it may be pricier to omit printing a letter but to then "move to" the
                 // cell to the right. So there should be a price N for the jump, and wait until we see
                 // N bytes without changes to actually jump. If it changes before that, flush the
@@ -468,12 +473,13 @@ impl PrintBuffer {
 
             current_pos.x += width.as_usize();
 
+            *frozen = active.clone();
+
             // Assume we never wrap over?
         }
 
         // Keep the active buffer the same, because why not?
         // We could also flush it to Nones?
-        self.frozen_buffer.clone_from_slice(&self.active_buffer);
     }
 }
 


### PR DESCRIPTION
- Moved `persistent` flag to type level. Now compiler knows it value at compile time and optimize it away. It almost have no impact on performance, but it helps to split implementation of `flush_to_backend()` on 2 cases and may helps to experiment and optimize in the future.
- Replaced `clone_from_slice()` with manual copy `actual` cell to `frozen`. First of all, I want to note `Cell` is not `Copy` and can't be copied as 1 slice of memory, therefore I suppose `clone_from_slice()` unfolded by compiler just in loop of clones from `actual` cell to `frozen`. But moving this `clone()` to the existing loop like in PR changes usually we skip  many call of `clone()`, because of in common case changing only part of screen.

By my tests of performance this changes give about 20-30% speed up

For tests I measure time of invocation `PrintBuffer::flush()` on different examples:
- lorem - not modified example, tested just scrolling
- lorem (war and peace) - changed test to just English text that fill allmost all screen, tested just scrolling
- progress - not modified example, tested just changes from progress changing
- progress - changed count of progress bars to 200, tested just changes from progress changing

[time_lorem_(war_and_peace)_after.txt](https://github.com/user-attachments/files/18926649/time_lorem_.war_and_peace._after.txt)
[time_lorem_(war_and_peace)_before.txt](https://github.com/user-attachments/files/18926650/time_lorem_.war_and_peace._before.txt)
[time_lorem_after.txt](https://github.com/user-attachments/files/18926651/time_lorem_after.txt)
[time_lorem_before.txt](https://github.com/user-attachments/files/18926652/time_lorem_before.txt)
[time_progress_after.txt](https://github.com/user-attachments/files/18926653/time_progress_after.txt)
[time_progress_before.txt](https://github.com/user-attachments/files/18926654/time_progress_before.txt)
[time_progress_mod_after.txt](https://github.com/user-attachments/files/18926655/time_progress_mod_after.txt)
[time_progress_mod_before.txt](https://github.com/user-attachments/files/18926656/time_progress_mod_before.txt)
