### PR TITLE
Add LICENSE to cursive-macros Cargo.toml

### DIFF
--- a/cursive-macros/Cargo.toml
+++ b/cursive-macros/Cargo.toml
@@ -10,7 +10,7 @@ name = "cursive-macros"
 readme = "Readme.md"
 repository = "https://github.com/gyscos/cursive"
 version = "0.1.0"
-include = ["src/**/*"]
+include = ["src/**/*", "/LICENSE"]
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
Apologies for the churn, a Rust expert caught this issue in the Fedora Review process.

This fixes the previous commit, for some reason cargo-publish won't
pick up the LICENSE symlink without this change.

Signed-off-by: Alexander F. Lent <lx@xanderlent.com>
