### PR TITLE
enable iterating SelectView items in reverse

### DIFF
--- a/cursive-core/src/views/select_view.rs
+++ b/cursive-core/src/views/select_view.rs
@@ -12,6 +12,7 @@ use crate::{
 };
 use std::borrow::Borrow;
 use std::cmp::{min, Ordering};
+use std::iter;
 use std::sync::atomic::AtomicUsize;
 use std::sync::{Arc, Mutex};
 
@@ -392,7 +393,7 @@ impl<T: 'static + Send + Sync> SelectView<T> {
     /// `Arc<T>` is still alive after calling `SelectView::selection()`).
     ///
     /// If `T` does not implement `Clone`, check `SelectView::try_iter_mut()`.
-    pub fn iter_mut(&mut self) -> impl Iterator<Item = (&mut StyledString, &mut T)>
+    pub fn iter_mut(&mut self) -> impl ItemIterMut<'_, T>
     where
         T: Clone,
     {
@@ -408,7 +409,7 @@ impl<T: 'static + Send + Sync> SelectView<T> {
     ///
     /// Some items may not be returned mutably, for example if a `Arc<T>` is
     /// still alive after calling `SelectView::selection()`.
-    pub fn try_iter_mut(&mut self) -> impl Iterator<Item = (&mut StyledString, Option<&mut T>)> {
+    pub fn try_iter_mut(&mut self) -> impl ItemIterMutOpt<'_, T> {
         self.last_required_size = None;
         self.items
             .iter_mut()
@@ -418,7 +419,7 @@ impl<T: 'static + Send + Sync> SelectView<T> {
     /// Iterate on the items in this view.
     ///
     /// Returns an iterator with each item and their labels.
-    pub fn iter(&self) -> impl Iterator<Item = (&str, &T)> {
+    pub fn iter(&self) -> impl ItemIter<'_, T> {
         self.items
             .iter()
             .map(|item| (item.label.source(), &*item.value))
@@ -1131,6 +1132,44 @@ struct Blueprint {
 
     #[blueprint(foreach = add_item_str)]
     items: Vec<String>,
+}
+
+pub trait ItemIter<'a, T: 'a>:
+    Iterator<Item = (&'a str, &'a T)> + iter::DoubleEndedIterator + iter::ExactSizeIterator
+{
+}
+
+impl<'a, T: 'a, I> ItemIter<'a, T> for I where
+    I: Iterator<Item = (&'a str, &'a T)> + iter::DoubleEndedIterator + iter::ExactSizeIterator
+{
+}
+
+pub trait ItemIterMut<'a, T: 'a>:
+    Iterator<Item = (&'a mut StyledString, &'a mut T)>
+    + iter::DoubleEndedIterator
+    + iter::ExactSizeIterator
+{
+}
+
+impl<'a, T: 'a, I> ItemIterMut<'a, T> for I where
+    I: Iterator<Item = (&'a mut StyledString, &'a mut T)>
+        + iter::DoubleEndedIterator
+        + iter::ExactSizeIterator
+{
+}
+
+pub trait ItemIterMutOpt<'a, T: 'a>:
+    Iterator<Item = (&'a mut StyledString, Option<&'a mut T>)>
+    + iter::DoubleEndedIterator
+    + iter::ExactSizeIterator
+{
+}
+
+impl<'a, T: 'a, I> ItemIterMutOpt<'a, T> for I where
+    I: Iterator<Item = (&'a mut StyledString, Option<&'a mut T>)>
+        + iter::DoubleEndedIterator
+        + iter::ExactSizeIterator
+{
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This adds iterator trait aliases for SelectView::iter/iter_mut/try_iter_mut.

Instead of returning `impl Iterator<...>`, they can effectively return `impl Iterator<...> + DoubleEndedIterator + ExactSizeIterator`.

This lets you iterate in reverse if you want, which isn't currently possible since it just returns `impl Iterator`, despite being supported by the underlying iterator.

I believe this should be seamlessly backwards-compatible, since it's returning a type with the strict superset of traits it previously did, and the previous return type was an opaque type.