### PR TITLE
Fix Alt+Shift+Char for crossterm backend

### DIFF
--- a/cursive/src/backends/crossterm.rs
+++ b/cursive/src/backends/crossterm.rs
@@ -102,6 +102,11 @@ fn translate_event(event: CKeyEvent) -> Option<Event> {
                 ..
             } => Event::AltChar(c),
             CKeyEvent {
+                modifiers: ALT_SHIFT,
+                code: KeyCode::Char(c),
+                ..
+            } => Event::AltChar(c),
+            CKeyEvent {
                 modifiers: KeyModifiers::SHIFT,
                 code: KeyCode::Char(c),
                 ..


### PR DESCRIPTION
Before this patch `cargo run --example key_codes --features crossterm-backend`:

    AltChar('e')
    Char('E')

After:

    AltChar('e')
    AltChar('E')