### PR TITLE
Properly clear terminal on Cursive::clear()

### DIFF
--- a/cursive-core/src/cursive_root.rs
+++ b/cursive-core/src/cursive_root.rs
@@ -39,7 +39,7 @@ pub struct Cursive {
 
     menubar: views::Menubar,
 
-    pub(crate) needs_clear: bool,
+    needs_clear: bool,
 
     running: bool,
 
@@ -126,16 +126,16 @@ impl Cursive {
     pub(crate) fn draw(&mut self, buffer: &RwLock<crate::buffer::PrintBuffer>) {
         let size = buffer.read().size();
 
-        let printer = Printer::new(size, &self.theme, buffer);
-
         if self.needs_clear {
-            printer.clear();
+            buffer.write().clear();
             self.needs_clear = false;
         }
 
         let selected = self.menubar.receive_events();
 
         let offset = usize::from(!self.menubar.autohide);
+
+        let printer = Printer::new(size, &self.theme, buffer);
 
         // The printer for the stackview
         let sv_printer = printer.offset((0, offset)).focused(!selected);


### PR DESCRIPTION
Using `buffer.write().clear()` over `printer.clear()` (which is `self.buffer.write().fill(" ")`) helps with properly clear the cursive screen area after invoking side TUI apps within it (i.e. vim)

Note, that this is not enough to clear the complete screen in case of using ShadowView.