### PR TITLE
Address most compiler/clippy warnings

### DIFF
--- a/cursive-core/src/buffer.rs
+++ b/cursive-core/src/buffer.rs
@@ -10,9 +10,10 @@ use unicode_width::UnicodeWidthStr;
 /// The width of a cell.
 ///
 /// Most characters are single-width. Some asian characters and emojis are double-width.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 pub enum CellWidth {
     /// This character takes a single cell in the grid.
+    #[default]
     Single,
 
     /// This character takes 2 cells in the grid (mostly for emojis and asian characters).
@@ -26,12 +27,6 @@ pub enum CellWidth {
 
     /// This character takes 5 cells in the grid (hindi???).
     Quintuple,
-}
-
-impl Default for CellWidth {
-    fn default() -> Self {
-        CellWidth::Single
-    }
 }
 
 impl CellWidth {

--- a/cursive-core/src/menu.rs
+++ b/cursive-core/src/menu.rs
@@ -99,7 +99,7 @@ impl Item {
     /// Returns the styled lable for this item
     ///
     /// Returns a vertical bar string if `self` is a delimiter.
-    pub fn styled_label(&self) -> SpannedStr<Style> {
+    pub fn styled_label(&self) -> SpannedStr<'_, Style> {
         match *self {
             Item::Delimiter => DELIMITER.as_styled_str(),
             Item::Leaf { ref label, .. } | Item::Subtree { ref label, .. } => {

--- a/cursive-core/src/style/color_style.rs
+++ b/cursive-core/src/style/color_style.rs
@@ -298,7 +298,7 @@ where
 /// Either a color from the palette, or a direct color.
 ///
 /// The `Default` implementation returns `InheritParent`.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Default)]
 pub enum ColorType {
     /// Uses a color from the application palette.
     ///
@@ -310,13 +310,8 @@ pub enum ColorType {
     Color(Color),
 
     /// Re-uses the color from the parent.
+    #[default]
     InheritParent,
-}
-
-impl Default for ColorType {
-    fn default() -> Self {
-        ColorType::InheritParent
-    }
 }
 
 impl ColorType {

--- a/cursive-core/src/utils/markup/mod.rs
+++ b/cursive-core/src/utils/markup/mod.rs
@@ -83,7 +83,7 @@ impl<'a> PlainStr<'a> {
     }
 
     /// Get a `StyledStr` borrowing this `PlainStr`.
-    pub fn as_styled_str(&self) -> StyledStr {
+    pub fn as_styled_str(&self) -> StyledStr<'_> {
         StyledStr::from_spanned_text(self)
     }
 }

--- a/cursive-core/src/vec.rs
+++ b/cursive-core/src/vec.rs
@@ -202,7 +202,7 @@ impl XY<usize> {
 impl<T: Sub<Output = T> + Mul<Output = T> + Add<Output = T> + Copy> XY<T> {
     /// Returns the square distance between `a` and `b`.
     pub fn sq_norm(self) -> T {
-        self.map(|x| (x * x)).sum()
+        self.map(|x| x * x).sum()
     }
 }
 

--- a/cursive-core/src/view/scroll/mod.rs
+++ b/cursive-core/src/view/scroll/mod.rs
@@ -28,20 +28,15 @@ use crate::event::{Event, EventResult};
 use crate::{Printer, Rect, Vec2};
 
 /// Defines the scrolling behaviour on content or size change
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub enum ScrollStrategy {
     /// Keeps the same row number
+    #[default]
     KeepRow,
     /// Sticks to the top.
     StickToTop,
     /// Sticks to the bottom of the view.
     StickToBottom,
-}
-
-impl Default for ScrollStrategy {
-    fn default() -> Self {
-        ScrollStrategy::KeepRow
-    }
 }
 
 impl std::str::FromStr for ScrollStrategy {

--- a/cursive-core/src/view/view_trait.rs
+++ b/cursive-core/src/view/view_trait.rs
@@ -83,10 +83,10 @@ pub trait View: Any + AnyView + Send + Sync {
     ///
     /// You can return an `EventResult`:
     /// * `EventResult::Ignored` means the event was not processed and may be
-    ///    sent to another view.
+    ///   sent to another view.
     /// * `EventResult::Consumed` means the event was consumed and should not
-    ///    be sent to any other view. It may in addition include a callback
-    ///    to be run.
+    ///   be sent to any other view. It may in addition include a callback
+    ///   to be run.
     ///
     /// The default implementation just ignores any event.
     fn on_event(&mut self, _: Event) -> EventResult {

--- a/cursive-core/src/views/checkbox.rs
+++ b/cursive-core/src/views/checkbox.rs
@@ -1,4 +1,4 @@
-use ahash::{HashSet, HashSetExt};
+use ahash::HashSet;
 
 use crate::{
     direction::Direction,

--- a/cursive-core/src/views/edit_view.rs
+++ b/cursive-core/src/views/edit_view.rs
@@ -644,7 +644,7 @@ impl View for EditView {
             Event::Key(Key::Left) | Event::CtrlChar('b') if self.cursor > 0 => {
                 let len = self.content[..self.cursor]
                     .graphemes(true)
-                    .last()
+                    .next_back()
                     .unwrap()
                     .len();
                 let cursor = self.cursor - len;
@@ -662,7 +662,7 @@ impl View for EditView {
             Event::Key(Key::Backspace) if self.cursor > 0 => {
                 let len = self.content[..self.cursor]
                     .graphemes(true)
-                    .last()
+                    .next_back()
                     .unwrap()
                     .len();
                 self.cursor -= len;

--- a/cursive-core/src/views/menu_popup.rs
+++ b/cursive-core/src/views/menu_popup.rs
@@ -350,7 +350,7 @@ impl View for MenuPopup {
         scroll::draw_box_frame(
             self,
             printer,
-            |s, y| s.menu.children.get(y).map_or(false, |c| c.is_delimiter()),
+            |s, y| s.menu.children.get(y).is_some_and(|c| c.is_delimiter()),
             |_s, _x| false,
         );
 

--- a/cursive-core/src/views/select_view.rs
+++ b/cursive-core/src/views/select_view.rs
@@ -393,10 +393,9 @@ impl<T: 'static + Send + Sync> SelectView<T> {
     /// `Arc<T>` is still alive after calling `SelectView::selection()`).
     ///
     /// If `T` does not implement `Clone`, check `SelectView::try_iter_mut()`.
-    pub fn iter_mut(&mut self)
-        -> impl Iterator<Item = (&mut StyledString, &mut T)>
-            + iter::DoubleEndedIterator
-            + iter::ExactSizeIterator
+    pub fn iter_mut(
+        &mut self,
+    ) -> impl iter::DoubleEndedIterator<Item = (&mut StyledString, &mut T)> + iter::ExactSizeIterator
     where
         T: Clone,
     {
@@ -412,11 +411,10 @@ impl<T: 'static + Send + Sync> SelectView<T> {
     ///
     /// Some items may not be returned mutably, for example if a `Arc<T>` is
     /// still alive after calling `SelectView::selection()`.
-    pub fn try_iter_mut(&mut self)
-        -> impl Iterator<Item = (&mut StyledString, Option<&mut T>)>
-            + iter::DoubleEndedIterator
-            + iter::ExactSizeIterator
-    {
+    pub fn try_iter_mut(
+        &mut self,
+    ) -> impl iter::DoubleEndedIterator<Item = (&mut StyledString, Option<&mut T>)>
+           + iter::ExactSizeIterator {
         self.last_required_size = None;
         self.items
             .iter_mut()
@@ -426,11 +424,9 @@ impl<T: 'static + Send + Sync> SelectView<T> {
     /// Iterate on the items in this view.
     ///
     /// Returns an iterator with each item and their labels.
-    pub fn iter(&self)
-        -> impl Iterator<Item = (&str, &T)>
-            + iter::DoubleEndedIterator
-            + iter::ExactSizeIterator
-    {
+    pub fn iter(
+        &self,
+    ) -> impl iter::DoubleEndedIterator<Item = (&str, &T)> + iter::ExactSizeIterator {
         self.items
             .iter()
             .map(|item| (item.label.source(), &*item.value))

--- a/cursive-core/src/views/text_area.rs
+++ b/cursive-core/src/views/text_area.rs
@@ -258,7 +258,7 @@ impl TextArea {
             }
 
             let text = &self.content[self.rows[row].start..self.cursor];
-            text.graphemes(true).last().unwrap().len()
+            text.graphemes(true).next_back().unwrap().len()
         };
         self.cursor -= len;
     }

--- a/cursive/src/backends/crossterm.rs
+++ b/cursive/src/backends/crossterm.rs
@@ -258,7 +258,7 @@ impl Backend {
         });
     }
 
-    fn stdout_mut(&self) -> RefMut<BufWriter<Stdout>> {
+    fn stdout_mut(&self) -> RefMut<'_, BufWriter<Stdout>> {
         self.stdout.borrow_mut()
     }
 

--- a/cursive/src/backends/puppet/observed.rs
+++ b/cursive/src/backends/puppet/observed.rs
@@ -169,7 +169,7 @@ impl ObservedScreen {
     }
 
     /// Returns a rectangular subset of observed screen.
-    pub fn piece(&self, min: Vec2, max: Vec2) -> ObservedPiece {
+    pub fn piece(&self, min: Vec2, max: Vec2) -> ObservedPiece<'_> {
         ObservedPiece::new(self, min, max)
     }
 
@@ -179,7 +179,7 @@ impl ObservedScreen {
     }
 
     /// Returns occurrences of given string pattern
-    pub fn find_occurences(&self, pattern: &str) -> Vec<ObservedLine> {
+    pub fn find_occurences(&self, pattern: &str) -> Vec<ObservedLine<'_>> {
         // TODO(njskalski): test for two-cell letters.
         // TODO(njskalski): fails with whitespaces like "\t".
 
@@ -282,7 +282,7 @@ pub trait ObservedPieceInterface {
     /// Returns expanded sibling of this piece
     ///
     /// Asserts if request can be satisfied.
-    fn expanded(&self, up_left: Vec2, down_right: Vec2) -> ObservedPiece {
+    fn expanded(&self, up_left: Vec2, down_right: Vec2) -> ObservedPiece<'_> {
         assert!(self.min().x >= up_left.x);
         assert!(self.min().y >= up_left.y);
         assert!(self.max().x + down_right.x <= self.parent().size.x);


### PR DESCRIPTION
I've been working on #857, and have noticed when trying to address any warnings in my code, that they're getting a bit lost in other warnings. This PR just addresses the warnings that have obvious solutions, which ended up being all of them except for one dead code warning.