### PR TITLE
Support tuple structs in wrap_impl!

### DIFF
--- a/cursive-core/src/view/view_wrapper.rs
+++ b/cursive-core/src/view/view_wrapper.rs
@@ -157,11 +157,17 @@ impl<T: ViewWrapper> View for T {
 /// impl<T: View> ViewWrapper for FooView<T> {
 ///     cursive_core::wrap_impl!(self.view: T);
 /// }
+///
+/// struct BarView<T: View>(T);
+///
+/// impl<T: View> ViewWrapper for BarView<T> {
+///     cursive_core::wrap_impl!(self.0: T);
+/// }
 /// # fn main() { }
 /// ```
 #[macro_export]
 macro_rules! wrap_impl {
-    (self.$v:ident: $t:ty) => {
+    (self.$v:tt: $t:ty) => {
         type V = $t;
 
         fn with_view<F, R>(&self, f: F) -> ::std::option::Option<R>

--- a/cursive-core/src/view/view_wrapper.rs
+++ b/cursive-core/src/view/view_wrapper.rs
@@ -231,3 +231,38 @@ macro_rules! inner_getters {
         }
     };
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[allow(dead_code, unused_variables)]
+    fn standard_struct() {
+        struct FooView<T: View> {
+            view: T,
+            enabled: bool,
+        }
+
+        impl<T: View> ViewWrapper for FooView<T> {
+            wrap_impl!(self.view: T);
+        }
+
+        let foo = FooView {
+            view: crate::views::TextView::new("Hello, World!"),
+            enabled: true,
+        };
+    }
+
+    #[test]
+    #[allow(dead_code, unused_variables)]
+    fn tuple_struct() {
+        struct BarView<T: View>(T);
+
+        impl<T: View> ViewWrapper for BarView<T> {
+            wrap_impl!(self.0: T);
+        }
+
+        let bar = BarView(crate::views::TextView::new("Hello, World!"));
+    }
+}


### PR DESCRIPTION
Change the fragment specifier used in `wrap_impl!` from `ident` to `tt`. Using `ident` was sufficient for "standard" structs with named fields. However, tuple structs are accessed via index numbers, which are not matched by `ident`. Although using `literal` for tuple indices seems like it should work, it does not.

Sidestep this issue by matching an `tt`, i.e. any valid token tree.

Fixes #866