### PR TITLE
Add horizontal scroll gesture support

### DIFF
--- a/cursive-core/src/event.rs
+++ b/cursive-core/src/event.rs
@@ -494,12 +494,16 @@ pub enum MouseEvent {
     WheelUp,
     /// The wheel was moved down.
     WheelDown,
+    /// The wheel was moved to the left.
+    WheelLeft,
+    /// The wheel was moved to the right.
+    WheelRight,
 }
 
 impl MouseEvent {
     /// Returns the button used by this event, if any.
     ///
-    /// Returns `None` if `self` is `WheelUp` or `WheelDown`.
+    /// Returns `None` if `self` is `WheelUp`, `WheelDown`, `WheelLeft` or `WheelRight`.
     pub fn button(self) -> Option<MouseButton> {
         match self {
             MouseEvent::Press(btn) | MouseEvent::Release(btn) | MouseEvent::Hold(btn) => Some(btn),
@@ -509,7 +513,7 @@ impl MouseEvent {
 
     /// Returns `true` if `self` is an event that can grab focus.
     ///
-    /// This includes `Press`, `WheelUp` and `WheelDown`.
+    /// This includes `Press`, `WheelUp`, `WheelDown`, `WheelLeft` and `WheelRight`.
     ///
     /// It does _not_ include `Release` or `Hold`.
     ///
@@ -518,7 +522,11 @@ impl MouseEvent {
     pub fn grabs_focus(self) -> bool {
         matches!(
             self,
-            MouseEvent::Press(_) | MouseEvent::WheelUp | MouseEvent::WheelDown
+            MouseEvent::Press(_)
+                | MouseEvent::WheelUp
+                | MouseEvent::WheelDown
+                | MouseEvent::WheelLeft
+                | MouseEvent::WheelRight
         )
     }
 }

--- a/cursive-core/src/view/scroll/raw.rs
+++ b/cursive-core/src/view/scroll/raw.rs
@@ -252,6 +252,18 @@ pub fn on_event<Model: ?Sized>(
                     get_scroller(model).scroll_down(3);
                 }
                 Event::Mouse {
+                    event: MouseEvent::WheelLeft,
+                    ..
+                } if get_scroller(model).can_scroll_left() => {
+                    get_scroller(model).scroll_left(3);
+                }
+                Event::Mouse {
+                    event: MouseEvent::WheelRight,
+                    ..
+                } if get_scroller(model).can_scroll_right() => {
+                    get_scroller(model).scroll_right(3);
+                }
+                Event::Mouse {
                     event: MouseEvent::Press(MouseButton::Left),
                     position,
                     offset,

--- a/cursive/src/backends/crossterm.rs
+++ b/cursive/src/backends/crossterm.rs
@@ -289,10 +289,8 @@ impl Backend {
                     }
                     MouseEventKind::ScrollDown => MouseEvent::WheelDown,
                     MouseEventKind::ScrollUp => MouseEvent::WheelUp,
-                    MouseEventKind::ScrollLeft | MouseEventKind::ScrollRight => {
-                        // TODO: Currently unsupported.
-                        return None;
-                    }
+                    MouseEventKind::ScrollLeft => MouseEvent::WheelLeft,
+                    MouseEventKind::ScrollRight => MouseEvent::WheelRight,
                 };
 
                 Event::Mouse {


### PR DESCRIPTION
Add WheelLeft/WheelRight variants to MouseEvent and wire them through the crossterm backend and scroll view event handler. This enables horizontal touchpad/trackpad scrolling in scrollable views with scroll_x enabled.

Resolves feature request #871 