### PR TITLE
make cb_cink return a CbSink instead of a reference to a CbSink

### DIFF
--- a/cursive-core/src/cursive_root.rs
+++ b/cursive-core/src/cursive_root.rs
@@ -298,8 +298,8 @@ impl Cursive {
     /// // quit() will be called during the next event cycle
     /// siv.cb_sink().send(Box::new(|s| s.quit())).unwrap();
     /// ```
-    pub fn cb_sink(&self) -> &CbSink {
-        &self.cb_sink
+    pub fn cb_sink(&self) -> CbSink {
+        self.cb_sink.clone()
     }
 
     /// Selects the menubar.


### PR DESCRIPTION
you can clone a crossbeam_channel::sender (the sender returned by the cb_cink function) cheaply, so in my opinion it would be better to not return a reference